### PR TITLE
feat(ltk_overlay)!: apply string overrides to localized stringtables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,7 @@ dependencies = [
  "camino",
  "eyre",
  "image",
+ "indexmap",
  "itertools",
  "ltk_mod_project",
  "ltk_wad",
@@ -1687,6 +1688,7 @@ dependencies = [
 name = "ltk_mod_project"
 version = "0.4.1"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1702,6 +1704,7 @@ dependencies = [
  "camino",
  "glob",
  "image",
+ "indexmap",
  "itertools",
  "ltk_io_ext 0.2.1",
  "ltk_mod_project",
@@ -1724,10 +1727,12 @@ version = "0.3.1"
 dependencies = [
  "byteorder",
  "camino",
+ "indexmap",
  "ltk_fantome",
  "ltk_file",
  "ltk_mod_project",
  "ltk_modpkg",
+ "ltk_rst",
  "ltk_wad",
  "memmap2",
  "rayon",
@@ -1786,6 +1791,18 @@ dependencies = [
  "byteorder",
  "glam",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ltk_rst"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c47f87ae3e31064792f6f7a8b8d56da0ef9a83d92b419cce97f4d37a078a8110"
+dependencies = [
+ "byteorder",
+ "num_enum",
+ "thiserror 1.0.69",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ members = [
 
 [workspace.dependencies]
 camino = "1.1"
+indexmap = { version = "2", features = ["serde"] }
 ltk_wad = "0.2.13"
 sysinfo = "0.32"

--- a/crates/ltk_fantome/Cargo.toml
+++ b/crates/ltk_fantome/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["game-development"]
 authors = ["LeagueToolkit"]
 
 [dependencies]
+indexmap = { workspace = true }
 zip = "2.2.0"
 image = "0.25.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/ltk_fantome/src/lib.rs
+++ b/crates/ltk_fantome/src/lib.rs
@@ -1,5 +1,6 @@
 use eyre::Result;
 use image::ImageFormat;
+use indexmap::IndexMap;
 use ltk_mod_project::{ModProject, ModProjectAuthor, ModProjectLayer};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -60,9 +61,9 @@ pub struct FantomeLayerInfo {
     #[serde(
         rename = "StringOverrides",
         default,
-        skip_serializing_if = "HashMap::is_empty"
+        skip_serializing_if = "IndexMap::is_empty"
     )]
-    pub string_overrides: HashMap<String, HashMap<String, String>>,
+    pub string_overrides: IndexMap<String, IndexMap<String, String>>,
 }
 
 /// Create a standard Fantome file name from a mod project.

--- a/crates/ltk_mod_project/Cargo.toml
+++ b/crates/ltk_mod_project/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["game-development"]
 authors = ["LeagueToolkit"]
 
 [dependencies]
+indexmap = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 toml = "0.8.19"

--- a/crates/ltk_mod_project/src/lib.rs
+++ b/crates/ltk_mod_project/src/lib.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
@@ -235,8 +236,8 @@ pub struct ModProjectLayer {
     /// String overrides for this layer, organized by locale.
     /// Outer key: locale (e.g., "en_us", "ko_kr", "zh_cn", or "default" for all locales)
     /// Inner map: field name (from lol.stringtable) -> new string value
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub string_overrides: HashMap<String, HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub string_overrides: IndexMap<String, IndexMap<String, String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -285,7 +286,7 @@ impl ModProjectLayer {
             display_name: None,
             priority: 0,
             description: Some("Base layer of the mod".to_string()),
-            string_overrides: HashMap::new(),
+            string_overrides: IndexMap::new(),
         }
     }
 }
@@ -297,7 +298,7 @@ pub fn default_layers() -> Vec<ModProjectLayer> {
         display_name: None,
         priority: 0,
         description: Some("Base layer of the mod".to_string()),
-        string_overrides: HashMap::new(),
+        string_overrides: IndexMap::new(),
     }]
 }
 
@@ -336,14 +337,14 @@ mod tests {
                     display_name: None,
                     priority: 0,
                     description: Some("Base layer of the mod".to_string()),
-                    string_overrides: HashMap::new(),
+                    string_overrides: IndexMap::new(),
                 },
                 ModProjectLayer {
                     name: "chroma1".to_string(),
                     display_name: Some("Chroma 1".to_string()),
                     priority: 20,
                     description: Some("Chroma 1".to_string()),
-                    string_overrides: HashMap::new(),
+                    string_overrides: IndexMap::new(),
                 },
             ],
             thumbnail: None,

--- a/crates/ltk_modpkg/Cargo.toml
+++ b/crates/ltk_modpkg/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["game-development"]
 authors = ["LeagueToolkit"]
 
 [dependencies]
+indexmap = { workspace = true }
 thiserror = "1.0.60"
 byteorder = "1.5.0"
 ltk_io_ext = "0.2.1"

--- a/crates/ltk_modpkg/src/metadata.rs
+++ b/crates/ltk_modpkg/src/metadata.rs
@@ -4,9 +4,9 @@ use crate::{
     license::ModpkgLicense,
     Modpkg,
 };
+use indexmap::IndexMap;
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::io::{Cursor, Read, Seek, Write};
 
 /// The path to the info.msgpack chunk.
@@ -80,10 +80,10 @@ impl DistributorInfo {
 /// # Example
 ///
 /// ```
-/// use std::collections::HashMap;
+/// use indexmap::IndexMap;
 /// use ltk_modpkg::ModpkgLayerMetadata;
 ///
-/// let mut en_us_overrides = HashMap::new();
+/// let mut en_us_overrides = IndexMap::new();
 /// en_us_overrides.insert("game_character_displayname_Ahri".to_string(), "Fox Spirit".to_string());
 ///
 /// let layer = ModpkgLayerMetadata {
@@ -91,7 +91,7 @@ impl DistributorInfo {
 ///     display_name: None,
 ///     priority: 0,
 ///     description: Some("Base layer".to_string()),
-///     string_overrides: HashMap::from([
+///     string_overrides: IndexMap::from([
 ///         ("en_us".to_string(), en_us_overrides),
 ///     ]),
 /// };
@@ -120,16 +120,21 @@ pub struct ModpkgLayerMetadata {
     /// Only the overrides are stored — not the full stringtable — so the
     /// mod stays compatible across game patches.
     /// Empty maps are omitted during serialization.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    #[cfg_attr(
-        test,
-        proptest(strategy = "proptest::collection::hash_map(\
-                \"[a-z]{2}_[a-z]{2}\", \
-                proptest::collection::hash_map(\"[a-z_]{1,30}\", \"[a-zA-Z0-9 ]{0,50}\", 0..3), \
-                0..2\
-            )")
-    )]
-    pub string_overrides: HashMap<String, HashMap<String, String>>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    #[cfg_attr(test, proptest(strategy = "string_overrides_strategy()"))]
+    pub string_overrides: IndexMap<String, IndexMap<String, String>>,
+}
+
+/// Proptest strategy for [`ModpkgLayerMetadata::string_overrides`].
+#[cfg(test)]
+fn string_overrides_strategy(
+) -> impl proptest::strategy::Strategy<Value = IndexMap<String, IndexMap<String, String>>> {
+    use proptest::strategy::Strategy;
+
+    let bucket = proptest::collection::vec(("[a-z_]{1,30}", "[a-zA-Z0-9 ]{0,50}"), 0..3)
+        .prop_map(|entries| entries.into_iter().collect::<IndexMap<_, _>>());
+    proptest::collection::vec(("[a-z]{2}_[a-z]{2}", bucket), 0..2)
+        .prop_map(|buckets| buckets.into_iter().collect())
 }
 
 /// The metadata of a mod package.
@@ -324,7 +329,7 @@ mod tests {
 
     proptest! {
         // Reduce test cases for CI performance (8 instead of default 256)
-        // The nested HashMap structure makes this test slow
+        // The nested map structure makes this test slow
         #![proptest_config(ProptestConfig::with_cases(8))]
 
         #[test]
@@ -442,9 +447,9 @@ mod tests {
             display_name: None,
             priority: 0,
             description: Some("Base layer".to_string()),
-            string_overrides: HashMap::from([(
+            string_overrides: IndexMap::from([(
                 "en_us".to_string(),
-                HashMap::from([
+                IndexMap::from([
                     ("field_a".to_string(), "New Value A".to_string()),
                     ("field_b".to_string(), "New Value B".to_string()),
                 ]),
@@ -463,7 +468,7 @@ mod tests {
             display_name: None,
             priority: 0,
             description: None,
-            string_overrides: HashMap::new(),
+            string_overrides: IndexMap::new(),
         };
 
         let encoded = rmp_serde::to_vec_named(&layer).unwrap();
@@ -496,7 +501,7 @@ mod tests {
                 display_name: None,
                 priority: 0,
                 description: None,
-                string_overrides: HashMap::new(),
+                string_overrides: IndexMap::new(),
             }],
         };
 
@@ -532,9 +537,9 @@ mod tests {
                     display_name: None,
                     priority: 0,
                     description: None,
-                    string_overrides: HashMap::from([(
+                    string_overrides: IndexMap::from([(
                         "en_us".to_string(),
-                        HashMap::from([("game_stat_name".to_string(), "Custom Stat".to_string())]),
+                        IndexMap::from([("game_stat_name".to_string(), "Custom Stat".to_string())]),
                     )]),
                 },
                 ModpkgLayerMetadata {
@@ -542,9 +547,9 @@ mod tests {
                     display_name: Some("Pink chroma".to_string()),
                     priority: 10,
                     description: Some("Pink chroma".to_string()),
-                    string_overrides: HashMap::from([(
+                    string_overrides: IndexMap::from([(
                         "en_us".to_string(),
-                        HashMap::from([
+                        IndexMap::from([
                             ("champion_name".to_string(), "Custom Name".to_string()),
                             ("ability_desc".to_string(), "Custom Description".to_string()),
                         ]),

--- a/crates/ltk_modpkg/src/project/tests.rs
+++ b/crates/ltk_modpkg/src/project/tests.rs
@@ -2,8 +2,8 @@ use super::packer::{compression_for_extension, is_valid_slug};
 use super::*;
 use crate::{Modpkg, ModpkgCompression};
 use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexMap;
 use ltk_mod_project::{ModProject, ModProjectAuthor, ModProjectLayer, ModProjectLicense};
-use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::Cursor;
 
@@ -21,7 +21,7 @@ fn new_rejects_invalid_layer_slug() {
         display_name: None,
         priority: 1,
         description: None,
-        string_overrides: HashMap::new(),
+        string_overrides: IndexMap::new(),
     }]);
 
     let err = ProjectPacker::with_mod_project(project, root.clone()).unwrap_err();
@@ -43,7 +43,7 @@ fn new_rejects_base_layer_with_wrong_priority() {
         display_name: None,
         priority: 5,
         description: None,
-        string_overrides: HashMap::new(),
+        string_overrides: IndexMap::new(),
     }]);
 
     let err = ProjectPacker::with_mod_project(project, root.clone()).unwrap_err();
@@ -68,7 +68,7 @@ fn new_rejects_missing_layer_directory() {
             display_name: None,
             priority: 1,
             description: None,
-            string_overrides: HashMap::new(),
+            string_overrides: IndexMap::new(),
         },
     ]);
 
@@ -190,7 +190,7 @@ fn pack_multi_wad_multi_layer() {
             display_name: None,
             priority: 1,
             description: None,
-            string_overrides: HashMap::new(),
+            string_overrides: IndexMap::new(),
         },
     ]);
 

--- a/crates/ltk_overlay/Cargo.toml
+++ b/crates/ltk_overlay/Cargo.toml
@@ -18,6 +18,8 @@ ltk_file = "0.2.8"
 ltk_mod_project = { version = "0.4.1", path = "../ltk_mod_project" }
 ltk_modpkg = { version = "0.5.0", path = "../ltk_modpkg" }
 ltk_fantome = { version = "0.5.1", path = "../ltk_fantome" }
+indexmap = { workspace = true }
+ltk_rst = "0.2.0"
 
 # Archive reading
 zip = "2.2.0"

--- a/crates/ltk_overlay/src/builder/metadata.rs
+++ b/crates/ltk_overlay/src/builder/metadata.rs
@@ -208,9 +208,12 @@ pub(crate) fn collect_single_mod_metadata(
 
 /// Filter out override metadata that should not be included in the overlay.
 ///
-/// This performs two filtering passes:
+/// This performs three filtering passes:
 /// 1. SubChunkTOC entries — always stripped to prevent game corruption.
-/// 2. Lazy overrides — mod files identical to game originals, detected by
+/// 2. Stringtable chunks — mods must not ship `lol.stringtable` overrides;
+///    layer `string_overrides` are the only supported way to modify game
+///    strings, and the game's own stringtable is always the patch base.
+/// 3. Lazy overrides — mod files identical to game originals, detected by
 ///    comparing pre-computed content hashes against game originals.
 pub(crate) fn filter_override_metadata(
     all_meta: &mut HashMap<u64, OverrideMeta>,
@@ -234,6 +237,23 @@ pub(crate) fn filter_override_metadata(
             filtered_count
         );
     }
+
+    // Reject mod-shipped stringtable chunks. The game's stringtable is always
+    // the base for string patching; layer `string_overrides` are the only
+    // supported way to modify game strings.
+    let stringtable_blocked = crate::strings::blocked_stringtable_hashes(game_index);
+    all_meta.retain(|path_hash, meta| {
+        let blocked = stringtable_blocked.contains(path_hash);
+        if blocked {
+            tracing::warn!(
+                "Mod '{}' ships a stringtable chunk ('{}'); rejecting it - use layer \
+                 string_overrides to modify game strings",
+                meta.source.mod_id(),
+                meta.source.rel_path(),
+            );
+        }
+        !blocked
+    });
 
     // Filter out lazy overrides — mod files identical to game originals.
     // Use pre-computed content_hash from metadata instead of re-reading bytes.
@@ -397,6 +417,7 @@ impl OverlayBuilder {
 mod tests {
     use super::*;
     use crate::meta_cache::CachedOverride;
+    use indexmap::IndexMap;
     use ltk_mod_project::{ModProject, ModProjectLayer};
     use std::sync::{Arc, Mutex};
 
@@ -461,7 +482,7 @@ mod tests {
                 display_name: None,
                 priority: i as i32,
                 description: None,
-                string_overrides: HashMap::new(),
+                string_overrides: IndexMap::new(),
             })
             .collect()
     }
@@ -716,6 +737,55 @@ mod tests {
             Some(ahri),
             "Override with no WAD match should be routed to the mod's dominant WAD"
         );
+    }
+
+    #[test]
+    fn test_filter_rejects_mod_shipped_stringtable_chunks() {
+        let mut wad_index = HashMap::new();
+        wad_index.insert(
+            "global.en_us.wad.client".to_string(),
+            vec![Utf8PathBuf::from(
+                "DATA/FINAL/Localized/Global.en_US.wad.client",
+            )],
+        );
+        let game_index = GameIndex {
+            wad_index,
+            hash_index: HashMap::new(),
+            game_fingerprint: 0,
+            subchunktoc_blocked: HashSet::new(),
+        };
+
+        let raw_meta = |rel_path: &str| OverrideMeta {
+            content_hash: 1,
+            uncompressed_size: 1,
+            source: OverrideSource::Raw {
+                mod_id: "strings-shipper".to_string(),
+                rel_path: Utf8PathBuf::from(rel_path),
+            },
+            fallback_wad: None,
+            linked_bins: Vec::new(),
+        };
+
+        let stringtable_hash = crate::strings::stringtable_chunk_hash("en_us");
+        let mut all_meta = HashMap::new();
+        all_meta.insert(
+            stringtable_hash,
+            raw_meta("data/menu/en_us/lol.stringtable"),
+        );
+        all_meta.insert(0xAAAA, raw_meta("assets/other.bin"));
+
+        let tmp = tempfile::tempdir().unwrap();
+        let game_dir_std = tmp.path().join("Game");
+        std::fs::create_dir_all(game_dir_std.join("DATA").join("FINAL")).unwrap();
+        let game_dir = Utf8Path::from_path(&game_dir_std).unwrap();
+
+        filter_override_metadata(&mut all_meta, &game_index, game_dir);
+
+        assert!(
+            !all_meta.contains_key(&stringtable_hash),
+            "Mod-shipped stringtable chunks must be rejected"
+        );
+        assert!(all_meta.contains_key(&0xAAAA));
     }
 
     #[test]

--- a/crates/ltk_overlay/src/builder/mod.rs
+++ b/crates/ltk_overlay/src/builder/mod.rs
@@ -31,6 +31,7 @@ use crate::error::{Error, Result};
 use crate::game_index::GameIndex;
 use crate::linked_bins::{collect_linked_bin_offenders, LinkedBinOffender};
 use crate::state::OverlayState;
+use crate::strings::{self, StringOverrideMode, StringPatchPlan};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
@@ -57,7 +58,17 @@ pub(crate) enum OverrideSource {
         mod_id: String,
         rel_path: Utf8PathBuf,
     },
+    /// Synthetic override produced by the string-override engine: the patched
+    /// `lol.stringtable` for one locale (encoded in the chunk path). Its bytes
+    /// are generated at resolve time (base chunk + key-level overrides) rather
+    /// than re-read from a provider, so this variant never enters the per-mod
+    /// metadata cache.
+    StringPatch { chunk_path: Utf8PathBuf },
 }
+
+/// Pseudo mod id reported for [`OverrideSource::StringPatch`] entries, which
+/// aggregate overrides from several mods.
+pub(crate) const STRING_PATCH_MOD_ID: &str = "string-overrides";
 
 impl OverrideSource {
     /// The id of the mod this override came from.
@@ -65,6 +76,7 @@ impl OverrideSource {
         match self {
             OverrideSource::LayerWad { mod_id, .. } => mod_id,
             OverrideSource::Raw { mod_id, .. } => mod_id,
+            OverrideSource::StringPatch { .. } => STRING_PATCH_MOD_ID,
         }
     }
 
@@ -73,6 +85,7 @@ impl OverrideSource {
         match self {
             OverrideSource::LayerWad { rel_path, .. } => rel_path.as_path(),
             OverrideSource::Raw { rel_path, .. } => rel_path.as_path(),
+            OverrideSource::StringPatch { chunk_path, .. } => chunk_path.as_path(),
         }
     }
 }
@@ -217,7 +230,8 @@ pub enum OverlayStage {
     CollectingOverrides,
     /// Building a patched WAD file in the overlay directory.
     PatchingWad,
-    /// Applying string table overrides (reserved for future use).
+    /// Merging string overrides from all enabled mods and planning stringtable
+    /// patches for the target locales.
     ApplyingStringOverrides,
     /// Build finished successfully.
     Complete,
@@ -381,6 +395,7 @@ pub struct OverlayBuilder {
     state_dir: Utf8PathBuf,
     enabled_mods: Vec<EnabledMod>,
     blocked_wads: HashSet<String>,
+    string_override_mode: StringOverrideMode,
     progress_callback: Option<ProgressCallback>,
     /// Per-mod WAD reports captured during the most recent successful
     /// [`build`](Self::build), drained via [`take_mod_wad_reports`](Self::take_mod_wad_reports).
@@ -409,6 +424,7 @@ impl OverlayBuilder {
             state_dir,
             enabled_mods: Vec::new(),
             blocked_wads: HashSet::new(),
+            string_override_mode: StringOverrideMode::Disabled,
             progress_callback: None,
             last_mod_wad_reports: Vec::new(),
             last_linked_bin_offenders: Vec::new(),
@@ -494,6 +510,16 @@ impl OverlayBuilder {
         self
     }
 
+    /// Configure which locales mods' string overrides are applied to.
+    ///
+    /// Defaults to [`StringOverrideMode::Disabled`], in which case
+    /// `ModProjectLayer::string_overrides` metadata is carried through but never
+    /// applied to the game's stringtables.
+    pub fn with_string_overrides(mut self, mode: StringOverrideMode) -> Self {
+        self.string_override_mode = mode;
+        self
+    }
+
     /// Set the ordered list of mods to include in the overlay.
     ///
     /// Order matters: the first mod in the list (index 0) has the highest priority.
@@ -539,6 +565,10 @@ impl OverlayBuilder {
         let cache_path = self.state_dir.join("game_index.bin");
         let game_index = GameIndex::load_or_build(&self.game_dir, &cache_path)?;
 
+        // Resolved locale targets are part of the build configuration: they enter
+        // the state comparison so toggling the mode invalidates the exact-match skip.
+        let target_locales = self.string_override_mode.resolve_locales(&game_index);
+
         // Load previous state
         let state_path = self.state_dir.join("overlay.json");
         let enabled_ids: Vec<String> = self.enabled_mods.iter().map(|m| m.id.clone()).collect();
@@ -552,6 +582,7 @@ impl OverlayBuilder {
                 Vec::new(),
                 game_index.game_fingerprint(),
                 effective_blocked.clone(),
+                target_locales.clone(),
                 BTreeMap::new(),
             );
             state.save(&state_path)?;
@@ -570,6 +601,7 @@ impl OverlayBuilder {
                 &enabled_ids,
                 game_index.game_fingerprint(),
                 &effective_blocked,
+                &target_locales,
             ) {
                 if self.validate_wads_exist(state) {
                     tracing::info!("Overlay: exact match, skipping build");
@@ -609,8 +641,11 @@ impl OverlayBuilder {
 
         self.emit_progress(OverlayProgress::stage(OverlayStage::CollectingOverrides));
 
-        let (all_meta, mod_wad_reports) = self.collect_all_override_metadata(&game_index)?;
+        let (mut all_meta, mod_wad_reports) = self.collect_all_override_metadata(&game_index)?;
         self.last_mod_wad_reports = mod_wad_reports;
+
+        let string_plans =
+            self.build_string_patch_plans(&game_index, &target_locales, &mut all_meta)?;
 
         let mut wad_hash_sets = self.distribute_override_hashes(&all_meta, &game_index);
 
@@ -637,8 +672,12 @@ impl OverlayBuilder {
         let (wads_to_build, wads_to_reuse, new_wad_fingerprints) =
             self.partition_wads_from_meta(&wad_hash_sets, &all_meta, &prev_state, can_incremental);
 
-        let wad_overrides =
-            self.resolve_overrides_for_wads(&wads_to_build, &wad_hash_sets, &all_meta)?;
+        let wad_overrides = self.resolve_overrides_for_wads(
+            &wads_to_build,
+            &wad_hash_sets,
+            &all_meta,
+            &string_plans,
+        )?;
 
         let built_paths = self.patch_wads_parallel(wads_to_build, wad_overrides)?;
 
@@ -657,6 +696,7 @@ impl OverlayBuilder {
             enabled_ids,
             game_index.game_fingerprint(),
             effective_blocked,
+            target_locales,
             new_wad_fingerprints,
         );
         state.linked_bin_offenders = self.last_linked_bin_offenders.clone();
@@ -703,6 +743,75 @@ impl OverlayBuilder {
     // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
+
+    /// Merge string overrides from all enabled mods and inject one synthetic
+    /// override entry per target locale into `all_meta` (pass 1).
+    ///
+    /// Returns the patch plans keyed by stringtable chunk hash. Only the plan
+    /// (merged override map + fingerprint) is computed here — the base table is
+    /// read and patched lazily in pass 2, and only for WADs being rebuilt, so
+    /// unchanged overrides never touch the game stringtable on incremental builds.
+    fn build_string_patch_plans(
+        &mut self,
+        game_index: &GameIndex,
+        target_locales: &[String],
+        all_meta: &mut HashMap<u64, OverrideMeta>,
+    ) -> Result<HashMap<u64, StringPatchPlan>> {
+        let mut plans = HashMap::new();
+        if target_locales.is_empty() {
+            return Ok(plans);
+        }
+
+        let per_locale =
+            strings::collect_effective_overrides(&mut self.enabled_mods, target_locales)?;
+        if per_locale.is_empty() {
+            return Ok(plans);
+        }
+
+        self.emit_progress(OverlayProgress::stage(
+            OverlayStage::ApplyingStringOverrides,
+        ));
+
+        for (locale, overrides) in per_locale {
+            let wad_name = format!("Global.{locale}.wad.client");
+            let wad_abs_path = match game_index.find_wad(&wad_name) {
+                Ok(path) => path.clone(),
+                Err(Error::WadNotFound(_)) => {
+                    tracing::warn!(
+                        "String overrides target locale '{}' but the game has no '{}'; skipping",
+                        locale,
+                        wad_name
+                    );
+                    continue;
+                }
+                Err(other) => return Err(other),
+            };
+            let wad_rel_path = wad_abs_path
+                .strip_prefix(&self.game_dir)
+                .map_err(|_| format!("WAD path is not under Game/: {}", wad_abs_path))?
+                .to_path_buf();
+
+            let chunk_hash = strings::stringtable_chunk_hash(&locale);
+
+            tracing::info!(
+                "String overrides: {} entries for locale '{}' -> {}",
+                overrides.len(),
+                locale,
+                wad_rel_path,
+            );
+
+            let plan = StringPatchPlan {
+                locale,
+                chunk_hash,
+                wad_rel_path,
+                overrides,
+            };
+            all_meta.insert(chunk_hash, plan.to_override_meta());
+            plans.insert(chunk_hash, plan);
+        }
+
+        Ok(plans)
+    }
 
     /// Check that all WADs listed in the state actually exist on disk.
     fn validate_wads_exist(&self, state: &OverlayState) -> bool {

--- a/crates/ltk_overlay/src/builder/resolve.rs
+++ b/crates/ltk_overlay/src/builder/resolve.rs
@@ -121,11 +121,19 @@ impl OverlayBuilder {
     /// Groups needed overrides by source mod, reads each file once via the
     /// targeted `read_wad_override_file` / `read_raw_override_file` methods,
     /// wraps bytes in `Arc` for cross-WAD sharing, and distributes to per-WAD maps.
+    ///
+    /// [`OverrideSource::StringPatch`] entries have no provider to re-read from;
+    /// their bytes are generated here from the matching plan in `string_plans`
+    /// (the game's own stringtable chunk + key-level overrides). A failure to
+    /// read or patch a stringtable is logged and skipped — the locale's WAD is
+    /// still written, just without the string patch — instead of failing the
+    /// whole build.
     pub(crate) fn resolve_overrides_for_wads(
         &mut self,
         wads_to_build: &[Utf8PathBuf],
         wad_hash_sets: &BTreeMap<Utf8PathBuf, HashSet<u64>>,
         all_meta: &HashMap<u64, OverrideMeta>,
+        string_plans: &HashMap<u64, StringPatchPlan>,
     ) -> Result<BTreeMap<Utf8PathBuf, HashMap<u64, SharedBytes>>> {
         // Collect all unique path_hashes needed across WADs to build
         let needed_hashes: HashSet<u64> = wads_to_build
@@ -138,13 +146,18 @@ impl OverlayBuilder {
             return Ok(BTreeMap::new());
         }
 
-        // Group needed hashes by source mod ID
+        // Group needed hashes by source mod ID; string patches resolve separately.
         let mut by_mod: HashMap<&str, Vec<u64>> = HashMap::new();
+        let mut string_patch_hashes: Vec<u64> = Vec::new();
         for &path_hash in &needed_hashes {
             if let Some(meta) = all_meta.get(&path_hash) {
                 let mod_id = match &meta.source {
                     OverrideSource::LayerWad { mod_id, .. } => mod_id.as_str(),
                     OverrideSource::Raw { mod_id, .. } => mod_id.as_str(),
+                    OverrideSource::StringPatch { .. } => {
+                        string_patch_hashes.push(path_hash);
+                        continue;
+                    }
                 };
                 by_mod.entry(mod_id).or_default().push(path_hash);
             }
@@ -182,8 +195,34 @@ impl OverlayBuilder {
                     OverrideSource::Raw { rel_path, .. } => {
                         provider.read_raw_override_file(rel_path)?
                     }
+                    OverrideSource::StringPatch { .. } => {
+                        unreachable!("StringPatch sources are filtered out of the by-mod grouping")
+                    }
                 };
                 resolved.insert(path_hash, Arc::from(bytes));
+            }
+        }
+
+        for path_hash in string_patch_hashes {
+            let plan = string_plans.get(&path_hash).ok_or_else(|| {
+                Error::Other(format!(
+                    "Missing string patch plan for chunk {:016x}",
+                    path_hash
+                ))
+            })?;
+            let patched =
+                strings::read_game_chunk(&self.game_dir, &plan.wad_rel_path, plan.chunk_hash)
+                    .and_then(|base_bytes| plan.apply(&base_bytes));
+            match patched {
+                Ok(bytes) => {
+                    resolved.insert(path_hash, Arc::from(bytes));
+                }
+                Err(e) => tracing::error!(
+                    "Failed to apply string overrides for locale '{}': {}; the game \
+                     stringtable is left unpatched",
+                    plan.locale,
+                    e
+                ),
             }
         }
 

--- a/crates/ltk_overlay/src/content.rs
+++ b/crates/ltk_overlay/src/content.rs
@@ -253,13 +253,30 @@ impl ModContentProvider for FsModContent {
     fn content_fingerprint(&self) -> Result<Option<u64>> {
         use xxhash_rust::xxh3::xxh3_64;
 
+        // Collect (path, size, mtime) for all files under content/, plus the
+        // project config — string overrides live in mod.config.json/.toml, so
+        // config edits must change the fingerprint even when content/ doesn't.
+        let mut entries: Vec<(String, u64, u64)> = Vec::new();
+
+        for config_name in ["mod.config.json", "mod.config.toml"] {
+            let config_path = self.mod_dir.join(config_name);
+            let Ok(meta) = std::fs::metadata(config_path.as_std_path()) else {
+                continue;
+            };
+            let mtime = meta
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            entries.push((config_name.to_string(), meta.len(), mtime));
+        }
+
         let content_dir = self.mod_dir.join("content");
-        if !content_dir.as_std_path().exists() {
+        if !content_dir.as_std_path().exists() && entries.is_empty() {
             return Ok(Some(0));
         }
 
-        // Collect (path, size, mtime) for all files under content/
-        let mut entries: Vec<(String, u64, u64)> = Vec::new();
         let mut stack = vec![content_dir];
 
         while let Some(dir) = stack.pop() {

--- a/crates/ltk_overlay/src/fantome_content.rs
+++ b/crates/ltk_overlay/src/fantome_content.rs
@@ -11,7 +11,7 @@
 use crate::content::{archive_fingerprint, ModContentProvider};
 use crate::error::{Error, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use ltk_mod_project::{default_layers, ModProject, ModProjectAuthor};
+use ltk_mod_project::{default_layers, ModProject, ModProjectAuthor, ModProjectLayer};
 use ltk_wad::Wad;
 use std::collections::HashMap;
 use std::io::{self, Cursor, Read, Seek};
@@ -205,6 +205,28 @@ impl<R: Read + Seek + Send + Sync> ModContentProvider for FantomeContent<R> {
         let info: ltk_fantome::FantomeInfo = serde_json::from_str(info_content)
             .map_err(|e| Error::Other(format!("Failed to parse fantome info.json: {}", e)))?;
 
+        // Map declared layers so per-layer string overrides survive; fantome WAD
+        // content itself is still base-layer only.
+        let mut layers: Vec<ModProjectLayer> = info
+            .layers
+            .iter()
+            .map(|(key, layer)| ModProjectLayer {
+                name: if layer.name.is_empty() {
+                    key.clone()
+                } else {
+                    layer.name.clone()
+                },
+                display_name: layer.display_name.clone(),
+                priority: layer.priority,
+                description: None,
+                string_overrides: layer.string_overrides.clone(),
+            })
+            .collect();
+        layers.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.name.cmp(&b.name)));
+        if !layers.iter().any(|l| l.name == "base") {
+            layers = default_layers().into_iter().chain(layers).collect();
+        }
+
         Ok(ModProject {
             name: slug::slugify(&info.name),
             display_name: info.name,
@@ -216,7 +238,7 @@ impl<R: Read + Seek + Send + Sync> ModContentProvider for FantomeContent<R> {
             champions: Vec::new(),
             maps: Vec::new(),
             transformers: Vec::new(),
-            layers: default_layers(),
+            layers,
             thumbnail: None,
         })
     }

--- a/crates/ltk_overlay/src/game_index.rs
+++ b/crates/ltk_overlay/src/game_index.rs
@@ -250,6 +250,28 @@ impl GameIndex {
         self.game_fingerprint
     }
 
+    /// Locales that have a `Global.{locale}.wad.client` in the game, paired with
+    /// the WAD's absolute path. Locales are lowercase (e.g. `"en_us"`), sorted,
+    /// and exclude the non-localized `Global.wad.client`.
+    pub fn localized_global_wads(&self) -> Vec<(String, &Utf8PathBuf)> {
+        let mut out: Vec<(String, &Utf8PathBuf)> = self
+            .wad_index
+            .iter()
+            .filter_map(|(name, paths)| {
+                let locale = name.strip_prefix("global.")?.strip_suffix(".wad.client")?;
+                if locale.is_empty() || locale.contains('.') {
+                    return None;
+                }
+                match paths.as_slice() {
+                    [single] => Some((locale.to_string(), single)),
+                    _ => None,
+                }
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
     /// Get the set of SubChunkTOC path hashes that mods must not override.
     pub fn subchunktoc_blocked(&self) -> &HashSet<u64> {
         &self.subchunktoc_blocked

--- a/crates/ltk_overlay/src/lib.rs
+++ b/crates/ltk_overlay/src/lib.rs
@@ -95,8 +95,12 @@ pub mod linked_bins;
 pub mod meta_cache;
 pub mod modpkg_content;
 pub mod state;
+pub mod strings;
 pub mod utils;
 pub mod wad_builder;
+
+#[cfg(test)]
+mod strings_integration_tests;
 
 // Re-export main public API.
 pub use builder::{
@@ -110,3 +114,4 @@ pub use game_index::GameIndex;
 pub use linked_bins::LinkedBinOffender;
 pub use modpkg_content::ModpkgContent;
 pub use state::OverlayState;
+pub use strings::StringOverrideMode;

--- a/crates/ltk_overlay/src/meta_cache.rs
+++ b/crates/ltk_overlay/src/meta_cache.rs
@@ -109,6 +109,11 @@ impl CachedModMeta {
                     OverrideSource::Raw { rel_path, .. } => {
                         (None, None, rel_path.as_str().to_string())
                     }
+                    // Synthetic string patches are injected after per-mod
+                    // collection, so they never reach the per-mod cache.
+                    OverrideSource::StringPatch { .. } => {
+                        unreachable!("StringPatch overrides are not cached per-mod")
+                    }
                 };
 
                 CachedOverride {

--- a/crates/ltk_overlay/src/state.rs
+++ b/crates/ltk_overlay/src/state.rs
@@ -60,6 +60,13 @@ pub struct OverlayState {
     #[serde(default)]
     pub blocked_wads: Vec<String>,
 
+    /// Sorted list of lowercased locales string overrides were applied to
+    /// (empty when string overrides are disabled). Changing the target locales
+    /// (e.g. switching the client language or toggling "all locales") must
+    /// invalidate the exact-match skip, so it participates in [`matches`](Self::matches).
+    #[serde(default)]
+    pub string_override_locales: Vec<String>,
+
     /// Per-WAD override fingerprints from the last build.
     ///
     /// Key: relative WAD path (e.g. `"DATA/FINAL/Champions/Aatrox.wad.client"`).
@@ -84,6 +91,7 @@ impl Default for OverlayState {
             enabled_mods: Vec::new(),
             game_fingerprint: 0,
             blocked_wads: Vec::new(),
+            string_override_locales: Vec::new(),
             wad_fingerprints: BTreeMap::new(),
             linked_bin_offenders: Vec::new(),
         }
@@ -98,11 +106,13 @@ impl OverlayState {
     /// * `enabled_mods` - List of enabled mod IDs in order
     /// * `game_fingerprint` - Fingerprint of the game directory
     /// * `blocked_wads` - Sorted list of lowercased blocked WAD filenames
+    /// * `string_override_locales` - Sorted list of lowercased string-override target locales
     /// * `wad_fingerprints` - Per-WAD override fingerprints
     pub fn new(
         enabled_mods: Vec<String>,
         game_fingerprint: u64,
         blocked_wads: Vec<String>,
+        string_override_locales: Vec<String>,
         wad_fingerprints: BTreeMap<String, u64>,
     ) -> Self {
         Self {
@@ -110,6 +120,7 @@ impl OverlayState {
             enabled_mods,
             game_fingerprint,
             blocked_wads,
+            string_override_locales,
             wad_fingerprints,
             linked_bin_offenders: Vec::new(),
         }
@@ -158,6 +169,7 @@ impl OverlayState {
     /// - Enabled mods list matches exactly (same IDs, same order)
     /// - Game fingerprint matches
     /// - Blocked WADs list matches
+    /// - String-override target locales match
     ///
     /// When this returns `true` and all WAD files exist on disk, the build can
     /// be skipped entirely.
@@ -167,16 +179,19 @@ impl OverlayState {
     /// * `enabled_mod_ids` - Current list of enabled mod IDs
     /// * `game_fingerprint` - Current game fingerprint
     /// * `blocked_wads` - Current sorted list of blocked WAD filenames
+    /// * `string_override_locales` - Current sorted list of string-override target locales
     pub fn matches(
         &self,
         enabled_mod_ids: &[String],
         game_fingerprint: u64,
         blocked_wads: &[String],
+        string_override_locales: &[String],
     ) -> bool {
         self.version == CURRENT_VERSION
             && self.enabled_mods == enabled_mod_ids
             && self.game_fingerprint == game_fingerprint
             && self.blocked_wads == blocked_wads
+            && self.string_override_locales == string_override_locales
     }
 
     /// Check if this state supports incremental rebuilding.
@@ -224,7 +239,13 @@ mod tests {
     #[test]
     fn test_new_state() {
         let mods = vec!["mod1".to_string(), "mod2".to_string()];
-        let state = OverlayState::new(mods.clone(), 0x123456, Vec::new(), BTreeMap::new());
+        let state = OverlayState::new(
+            mods.clone(),
+            0x123456,
+            Vec::new(),
+            Vec::new(),
+            BTreeMap::new(),
+        );
 
         assert_eq!(state.version, CURRENT_VERSION);
         assert_eq!(state.enabled_mods, mods);
@@ -242,7 +263,13 @@ mod tests {
         );
         wad_fps.insert("DATA/FINAL/Maps/Map11.wad.client".to_string(), 0xCAFEBABE);
 
-        let state = OverlayState::new(vec!["mod1".to_string()], 0x123, Vec::new(), wad_fps);
+        let state = OverlayState::new(
+            vec!["mod1".to_string()],
+            0x123,
+            Vec::new(),
+            Vec::new(),
+            wad_fps,
+        );
         assert_eq!(state.wad_fingerprints.len(), 2);
         assert_eq!(
             state.wad_fingerprint("DATA/FINAL/Champions/Aatrox.wad.client"),
@@ -258,9 +285,15 @@ mod tests {
     #[test]
     fn test_matches_identical() {
         let mods = vec!["mod1".to_string(), "mod2".to_string()];
-        let state = OverlayState::new(mods.clone(), 0x123456, Vec::new(), BTreeMap::new());
+        let state = OverlayState::new(
+            mods.clone(),
+            0x123456,
+            Vec::new(),
+            Vec::new(),
+            BTreeMap::new(),
+        );
 
-        assert!(state.matches(&mods, 0x123456, &[]));
+        assert!(state.matches(&mods, 0x123456, &[], &[]));
     }
 
     #[test]
@@ -269,11 +302,12 @@ mod tests {
             vec!["mod1".to_string()],
             0x123456,
             Vec::new(),
+            Vec::new(),
             BTreeMap::new(),
         );
         let other_mods = vec!["mod2".to_string()];
 
-        assert!(!state.matches(&other_mods, 0x123456, &[]));
+        assert!(!state.matches(&other_mods, 0x123456, &[], &[]));
     }
 
     #[test]
@@ -282,31 +316,38 @@ mod tests {
             vec!["mod1".to_string(), "mod2".to_string()],
             0x123456,
             Vec::new(),
+            Vec::new(),
             BTreeMap::new(),
         );
         let other_mods = vec!["mod2".to_string(), "mod1".to_string()];
 
-        assert!(!state.matches(&other_mods, 0x123456, &[]));
+        assert!(!state.matches(&other_mods, 0x123456, &[], &[]));
     }
 
     #[test]
     fn test_matches_different_fingerprint() {
         let mods = vec!["mod1".to_string()];
-        let state = OverlayState::new(mods.clone(), 0x123456, Vec::new(), BTreeMap::new());
+        let state = OverlayState::new(
+            mods.clone(),
+            0x123456,
+            Vec::new(),
+            Vec::new(),
+            BTreeMap::new(),
+        );
 
-        assert!(!state.matches(&mods, 0x789ABC, &[]));
+        assert!(!state.matches(&mods, 0x789ABC, &[], &[]));
     }
 
     #[test]
     fn test_matches_different_blocked_wads() {
         let mods = vec!["mod1".to_string()];
         let blocked = vec!["map22.wad.client".to_string()];
-        let state = OverlayState::new(mods.clone(), 0x123456, blocked, BTreeMap::new());
+        let state = OverlayState::new(mods.clone(), 0x123456, blocked, Vec::new(), BTreeMap::new());
 
         // Different blocked_wads should not match
-        assert!(!state.matches(&mods, 0x123456, &[]));
+        assert!(!state.matches(&mods, 0x123456, &[], &[]));
         // Same blocked_wads should match
-        assert!(state.matches(&mods, 0x123456, &["map22.wad.client".to_string()]));
+        assert!(state.matches(&mods, 0x123456, &["map22.wad.client".to_string()], &[]));
     }
 
     #[test]
@@ -314,6 +355,7 @@ mod tests {
         let state = OverlayState::new(
             vec!["mod1".to_string()],
             0x123456,
+            Vec::new(),
             Vec::new(),
             BTreeMap::new(),
         );
@@ -335,7 +377,7 @@ mod tests {
         assert!(state.blocked_wads.is_empty());
         assert!(state.wad_fingerprints.is_empty());
         assert!(!state.supports_incremental(1234));
-        assert!(!state.matches(&[String::from("mod1")], 1234, &[]));
+        assert!(!state.matches(&[String::from("mod1")], 1234, &[], &[]));
     }
 
     #[test]
@@ -347,7 +389,7 @@ mod tests {
         wad_fps.insert("DATA/FINAL/test.wad.client".to_string(), 0xABC);
 
         let mods = vec!["mod1".to_string(), "mod2".to_string()];
-        let state = OverlayState::new(mods.clone(), 0x123456, Vec::new(), wad_fps);
+        let state = OverlayState::new(mods.clone(), 0x123456, Vec::new(), Vec::new(), wad_fps);
 
         // Save
         state.save(path).unwrap();
@@ -387,6 +429,7 @@ mod tests {
             vec!["mod1".to_string()],
             0x123456,
             Vec::new(),
+            Vec::new(),
             BTreeMap::new(),
         );
         let json = serde_json::to_string(&state).unwrap();
@@ -395,6 +438,31 @@ mod tests {
         assert!(json.contains("\"enabledMods\""));
         assert!(json.contains("\"gameFingerprint\""));
         assert!(json.contains("\"blockedWads\""));
+        assert!(json.contains("\"stringOverrideLocales\""));
         assert!(json.contains("\"wadFingerprints\""));
+    }
+
+    #[test]
+    fn test_matches_different_string_override_locales() {
+        let mods = vec!["mod1".to_string()];
+        let locales = vec!["en_us".to_string()];
+        let state = OverlayState::new(
+            mods.clone(),
+            0x123456,
+            Vec::new(),
+            locales.clone(),
+            BTreeMap::new(),
+        );
+
+        assert!(state.matches(&mods, 0x123456, &[], &locales));
+        // Toggling the target locales must invalidate the exact-match skip.
+        assert!(!state.matches(&mods, 0x123456, &[], &[]));
+        assert!(!state.matches(&mods, 0x123456, &[], &["ko_kr".to_string()]));
+
+        // A pre-feature state file (no stringOverrideLocales) defaults to empty,
+        // so existing users without string overrides keep their skip path.
+        let v4_json = r#"{"version":4,"enabledMods":["mod1"],"gameFingerprint":1234}"#;
+        let old: OverlayState = serde_json::from_str(v4_json).unwrap();
+        assert!(old.matches(&mods, 1234, &[], &[]));
     }
 }

--- a/crates/ltk_overlay/src/strings.rs
+++ b/crates/ltk_overlay/src/strings.rs
@@ -1,0 +1,724 @@
+//! String-table override application.
+//!
+//! Mods declare per-layer, per-locale string overrides in their project metadata
+//! ([`ModProjectLayer::string_overrides`](ltk_mod_project::ModProjectLayer)),
+//! shaped `locale -> field key -> replacement`. At build time the overlay builder
+//! merges them across all enabled mods and applies them on top of the game's
+//! `data/menu/{locale}/lol.stringtable` chunk, producing a patched stringtable in
+//! the corresponding `Localized/Global.{locale}.wad.client` overlay WAD.
+//!
+//! The game's own stringtable is always the patch base: mod-shipped
+//! `lol.stringtable` chunk overrides are rejected during metadata collection
+//! (see [`blocked_stringtable_hashes`]) — `string_overrides` are the only
+//! supported way to modify game strings.
+//!
+//! # Merge semantics
+//!
+//! String conflicts resolve exactly like chunk conflicts:
+//!
+//! - Across mods, the mod closer to the front of the enabled list wins.
+//! - Within a mod, layers apply in ascending priority order (higher priority
+//!   layers overwrite lower ones).
+//! - Within a layer, the [`DEFAULT_LOCALE`] bucket applies before the
+//!   locale-specific bucket, so a locale-specific entry beats `"default"` in the
+//!   same layer — but never beats a higher-priority mod's `"default"` entry.
+//! - Keys are canonicalized to lowercase before merging (RST hashing lowercases
+//!   field names, so case variants of one key address the same table entry).
+//!   Buckets and keys keep their config document order, so when duplicates
+//!   collide — case variants of a bucket or key — the later entry in the file
+//!   wins.
+//!
+//! # Key syntax
+//!
+//! Keys are stringtable field names, lowercased and hashed by `ltk_rst` per the
+//! table's format. A key consisting of exactly 16 hex digits (a full 64-bit
+//! hash, e.g. `f772a83b33773223`) is treated as a pre-computed hash instead,
+//! for entries whose plaintext name is unknown.
+
+use crate::builder::{EnabledMod, OverrideMeta, OverrideSource};
+use crate::error::{Error, Result};
+use crate::game_index::GameIndex;
+use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexMap;
+use ltk_mod_project::ModProjectLayer;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::io::Cursor;
+use xxhash_rust::xxh3::xxh3_64;
+
+/// Locale bucket name whose overrides apply to every target locale.
+pub const DEFAULT_LOCALE: &str = "default";
+
+/// Which locales string overrides are applied to during an overlay build.
+///
+/// Configure via [`OverlayBuilder::with_string_overrides`](crate::OverlayBuilder::with_string_overrides).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum StringOverrideMode {
+    /// Skip string patching entirely.
+    #[default]
+    Disabled,
+    /// Patch only these locales (e.g. `["en_us"]`; case-insensitive).
+    Locales(Vec<String>),
+    /// Patch every locale that has a `Global.{locale}.wad.client` in the game.
+    AllInstalled,
+}
+
+impl StringOverrideMode {
+    /// Resolve the mode into a sorted, deduplicated list of lowercase locales.
+    ///
+    /// Locales without a matching `Global.{locale}.wad.client` are kept here and
+    /// skipped later with a warning when the WAD lookup fails, so a misconfigured
+    /// locale is visible in logs rather than silently dropped.
+    pub(crate) fn resolve_locales(&self, game_index: &GameIndex) -> Vec<String> {
+        let mut locales = match self {
+            StringOverrideMode::Disabled => Vec::new(),
+            StringOverrideMode::Locales(locales) => locales
+                .iter()
+                .map(|l| l.to_ascii_lowercase())
+                .collect::<Vec<_>>(),
+            StringOverrideMode::AllInstalled => game_index
+                .localized_global_wads()
+                .into_iter()
+                .map(|(locale, _)| locale)
+                .collect(),
+        };
+        locales.sort_unstable();
+        locales.dedup();
+        locales
+    }
+}
+
+/// The stringtable chunk path inside `Global.{locale}.wad.client`.
+pub(crate) fn stringtable_chunk_path(locale: &str) -> String {
+    format!("data/menu/{locale}/lol.stringtable")
+}
+
+/// The WAD chunk path hash of [`stringtable_chunk_path`] for `locale`.
+pub(crate) fn stringtable_chunk_hash(locale: &str) -> u64 {
+    ltk_modpkg::utils::hash_chunk_name(&ltk_modpkg::utils::normalize_chunk_path(
+        &stringtable_chunk_path(locale),
+    ))
+}
+
+/// Path hashes of the `lol.stringtable` chunks for every locale installed in
+/// the game.
+///
+/// Mods must not override these chunks directly — the game's stringtable is
+/// always the string-patch base — so any mod override with one of these path
+/// hashes is rejected during metadata filtering. Hash-based matching catches
+/// stringtables regardless of whether the mod ships them under a plaintext
+/// path or a raw hash filename.
+pub(crate) fn blocked_stringtable_hashes(game_index: &GameIndex) -> HashSet<u64> {
+    game_index
+        .localized_global_wads()
+        .into_iter()
+        .map(|(locale, _)| stringtable_chunk_hash(&locale))
+        .collect()
+}
+
+/// Parse a raw-hash key — exactly 16 hex digits (a full 64-bit hash) — into
+/// its `u64` value.
+fn parse_raw_hash_key(key: &str) -> Option<u64> {
+    if key.len() != 16 || !key.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    u64::from_str_radix(key, 16).ok()
+}
+
+/// A planned stringtable patch for one locale, computed in pass 1.
+///
+/// Carries everything needed to lazily generate the patched chunk bytes in
+/// pass 2 — the base table is only read (and the RST only parsed) when the
+/// target WAD actually needs rebuilding.
+pub(crate) struct StringPatchPlan {
+    /// Lowercase locale, e.g. `"en_us"`.
+    pub(crate) locale: String,
+    /// Path hash of the `lol.stringtable` chunk for this locale.
+    pub(crate) chunk_hash: u64,
+    /// Game-relative path of `Global.{locale}.wad.client`.
+    pub(crate) wad_rel_path: Utf8PathBuf,
+    /// Merged `field key -> replacement` map (sorted for determinism).
+    pub(crate) overrides: BTreeMap<String, String>,
+}
+
+impl StringPatchPlan {
+    /// Deterministic fingerprint of this patch's inputs, used as the synthetic
+    /// meta entry's `content_hash` so per-WAD fingerprints (and therefore
+    /// incremental rebuilds) react to any change in the effective overrides.
+    pub(crate) fn fingerprint(&self) -> u64 {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"ltk-string-patch-v2\0");
+        buf.extend_from_slice(self.locale.as_bytes());
+        buf.push(0);
+        for (key, value) in &self.overrides {
+            buf.extend_from_slice(key.as_bytes());
+            buf.push(0);
+            buf.extend_from_slice(value.as_bytes());
+            buf.push(0);
+        }
+        xxh3_64(&buf)
+    }
+
+    /// Parse `base_bytes` as an RST stringtable, apply this plan's overrides,
+    /// and serialize the patched table.
+    pub(crate) fn apply(&self, base_bytes: &[u8]) -> Result<Vec<u8>> {
+        let mut table =
+            ltk_rst::Stringtable::from_reader(&mut Cursor::new(base_bytes)).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to parse stringtable for locale '{}': {}",
+                    self.locale, e
+                ))
+            })?;
+
+        tracing::debug!(
+            "Applying {} string override(s) to '{}' stringtable ({} entries, format {:?})",
+            self.overrides.len(),
+            self.locale,
+            table.len(),
+            table.format()
+        );
+
+        for (key, value) in &self.overrides {
+            match parse_raw_hash_key(key) {
+                Some(hash) => table.insert(hash, value.clone()),
+                None => table.insert_str(key, value.clone()),
+            }
+        }
+
+        let mut out = Vec::with_capacity(base_bytes.len() + 1024);
+        table.to_writer(&mut out).map_err(|e| {
+            Error::Other(format!(
+                "Failed to write patched stringtable for locale '{}': {}",
+                self.locale, e
+            ))
+        })?;
+        Ok(out)
+    }
+
+    /// The synthetic override meta entry representing this patch in `all_meta`.
+    pub(crate) fn to_override_meta(&self) -> OverrideMeta {
+        OverrideMeta {
+            content_hash: self.fingerprint(),
+            uncompressed_size: 0,
+            source: OverrideSource::StringPatch {
+                chunk_path: Utf8PathBuf::from(stringtable_chunk_path(&self.locale)),
+            },
+            fallback_wad: Some(self.wad_rel_path.clone()),
+            linked_bins: Vec::new(),
+        }
+    }
+}
+
+/// Locale buckets in a layer's override map whose names match `locale`
+/// case-insensitively, in document order.
+///
+/// All case variants are returned, so duplicate buckets like `"en_US"` and
+/// `"EN_US"` merge in the order they appear in the config — the later bucket
+/// wins conflicts.
+fn buckets<'a>(
+    string_overrides: &'a IndexMap<String, IndexMap<String, String>>,
+    locale: &str,
+) -> Vec<&'a IndexMap<String, String>> {
+    string_overrides
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case(locale))
+        .map(|(_, map)| map)
+        .collect()
+}
+
+/// Merge string overrides from `enabled_mods` into one effective
+/// `locale -> field key -> replacement` map per target locale.
+///
+/// See the module docs for the conflict-resolution rules. Keys in the returned
+/// maps are canonicalized to lowercase. Locales whose effective map ends up
+/// empty are omitted.
+pub(crate) fn collect_effective_overrides(
+    enabled_mods: &mut [EnabledMod],
+    target_locales: &[String],
+) -> Result<HashMap<String, BTreeMap<String, String>>> {
+    let mut per_locale: HashMap<String, BTreeMap<String, String>> = HashMap::new();
+    if target_locales.is_empty() {
+        return Ok(per_locale);
+    }
+
+    // Front of the list wins, so fold back-to-front and let later writes overwrite.
+    for enabled_mod in enabled_mods.iter_mut().rev() {
+        let project = enabled_mod.content.mod_project()?;
+        let mut layers = project.layers;
+        layers.sort_by(|a, b| a.priority.cmp(&b.priority).then(a.name.cmp(&b.name)));
+
+        for layer in &layers {
+            if layer.string_overrides.is_empty() || !enabled_mod.is_layer_active(&layer.name) {
+                continue;
+            }
+
+            for locale in target_locales {
+                let effective = per_locale.entry(locale.clone()).or_default();
+                apply_layer_overrides(effective, layer, locale, &enabled_mod.id);
+            }
+        }
+    }
+
+    per_locale.retain(|_, map| !map.is_empty());
+    Ok(per_locale)
+}
+
+/// Apply one layer's overrides for `locale` onto the effective map — the
+/// [`DEFAULT_LOCALE`] bucket first, then the locale-specific one.
+fn apply_layer_overrides(
+    effective: &mut BTreeMap<String, String>,
+    layer: &ModProjectLayer,
+    locale: &str,
+    mod_id: &str,
+) {
+    for bucket_name in [DEFAULT_LOCALE, locale] {
+        for map in buckets(&layer.string_overrides, bucket_name) {
+            // Document order (IndexMap): when duplicate keys collapse to the
+            // same canonical key, the later entry in the config wins.
+            for (key, value) in map {
+                if let Some(canonical) = canonicalize_key(key, mod_id, &layer.name) {
+                    effective.insert(canonical, value.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Validate an override key and canonicalize it to lowercase — RST hashing
+/// lowercases field names, so case variants of one key must collide in the
+/// merge map for mod/layer priority to apply.
+///
+/// Invalid keys are logged with their mod/layer context and return `None`.
+fn canonicalize_key(key: &str, mod_id: &str, layer_name: &str) -> Option<String> {
+    if key.is_empty() {
+        tracing::warn!(
+            "Mod '{}' layer '{}' has an empty string-override key; skipping",
+            mod_id,
+            layer_name
+        );
+
+        return None;
+    }
+
+    Some(key.to_lowercase())
+}
+
+/// Read and decompress a single chunk from a game WAD.
+pub(crate) fn read_game_chunk(
+    game_dir: &Utf8Path,
+    wad_rel_path: &Utf8Path,
+    chunk_hash: u64,
+) -> Result<Vec<u8>> {
+    let abs_path = game_dir.join(wad_rel_path);
+    let file = std::fs::File::open(abs_path.as_std_path())?;
+    let mut wad = ltk_wad::Wad::mount(file)?;
+
+    let chunk = *wad.chunks().get(chunk_hash).ok_or_else(|| {
+        Error::Other(format!(
+            "Chunk {:016x} not found in game WAD '{}'",
+            chunk_hash, wad_rel_path
+        ))
+    })?;
+
+    Ok(wad.load_chunk_decompressed(&chunk)?.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::content::ModContentProvider;
+    use ltk_mod_project::{ModProject, ModProjectLayer};
+    use std::collections::HashSet;
+
+    fn table_bytes(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut table = ltk_rst::Stringtable::new();
+        for (key, value) in entries {
+            table.insert_str(*key, *value);
+        }
+        let mut out = Vec::new();
+        table.to_writer(&mut out).unwrap();
+        out
+    }
+
+    fn plan(overrides: &[(&str, &str)]) -> StringPatchPlan {
+        StringPatchPlan {
+            locale: "en_us".to_string(),
+            chunk_hash: stringtable_chunk_hash("en_us"),
+            wad_rel_path: Utf8PathBuf::from("DATA/FINAL/Localized/Global.en_US.wad.client"),
+            overrides: overrides
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    struct StringsOnlyContent {
+        layers: Vec<ModProjectLayer>,
+    }
+
+    impl ModContentProvider for StringsOnlyContent {
+        fn mod_project(&mut self) -> crate::error::Result<ModProject> {
+            Ok(ModProject {
+                name: "strings-mod".to_string(),
+                display_name: "Strings Mod".to_string(),
+                version: "1.0.0".to_string(),
+                description: String::new(),
+                authors: vec![],
+                license: None,
+                tags: vec![],
+                champions: vec![],
+                maps: vec![],
+                transformers: vec![],
+                layers: self.layers.clone(),
+                thumbnail: None,
+            })
+        }
+
+        fn list_layer_wads(&mut self, _layer: &str) -> crate::error::Result<Vec<String>> {
+            Ok(vec![])
+        }
+
+        fn read_wad_overrides(
+            &mut self,
+            _layer: &str,
+            _wad_name: &str,
+        ) -> crate::error::Result<Vec<(Utf8PathBuf, Vec<u8>)>> {
+            Ok(vec![])
+        }
+
+        fn read_wad_override_file(
+            &mut self,
+            _layer: &str,
+            _wad_name: &str,
+            _rel_path: &Utf8Path,
+        ) -> crate::error::Result<Vec<u8>> {
+            Ok(vec![])
+        }
+
+        fn read_raw_override_file(
+            &mut self,
+            _rel_path: &Utf8Path,
+        ) -> crate::error::Result<Vec<u8>> {
+            Ok(vec![])
+        }
+    }
+
+    fn layer(name: &str, priority: i32, buckets: &[(&str, &[(&str, &str)])]) -> ModProjectLayer {
+        ModProjectLayer {
+            name: name.to_string(),
+            display_name: None,
+            priority,
+            description: None,
+            string_overrides: buckets
+                .iter()
+                .map(|(locale, entries)| {
+                    (
+                        locale.to_string(),
+                        entries
+                            .iter()
+                            .map(|(k, v)| (k.to_string(), v.to_string()))
+                            .collect(),
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn strings_mod(id: &str, layers: Vec<ModProjectLayer>) -> EnabledMod {
+        EnabledMod {
+            id: id.to_string(),
+            content: Box::new(StringsOnlyContent { layers }),
+            enabled_layers: None,
+        }
+    }
+
+    #[test]
+    fn parse_raw_hash_key_variants() {
+        assert_eq!(
+            parse_raw_hash_key("f772a83b33773223"),
+            Some(0xf772a83b33773223)
+        );
+        assert_eq!(
+            parse_raw_hash_key("F772A83B33773223"),
+            Some(0xf772a83b33773223)
+        );
+        assert_eq!(
+            parse_raw_hash_key("0000000000000abc"),
+            Some(0xabc) // full width required, so zero-pad short hashes
+        );
+        assert_eq!(parse_raw_hash_key("abc"), None); // too short
+        assert_eq!(parse_raw_hash_key("0123456789abcdef0"), None); // 17 digits
+        assert_eq!(parse_raw_hash_key("{f772a83b33773223}"), None); // no braces
+        assert_eq!(parse_raw_hash_key("game_client_quit"), None);
+        assert_eq!(parse_raw_hash_key("stringtable_key!"), None); // 16 chars, not hex
+        assert_eq!(parse_raw_hash_key(""), None);
+    }
+
+    #[test]
+    fn apply_overrides_named_and_hash_keys() {
+        let base = table_bytes(&[("game_client_quit", "Quit"), ("untouched", "Original")]);
+
+        // Full 64-bit (untruncated) XXH3 of the key — ltk_rst masks it to the
+        // table's hash width on insert, so get_key("added_key") must find it.
+        let full_hash = xxhash_rust::xxh3::xxh3_64("added_key".as_bytes());
+
+        let patched = plan(&[
+            ("game_client_quit", "Bye"),
+            (&format!("{full_hash:016x}"), "Injected"),
+        ])
+        .apply(&base)
+        .unwrap();
+
+        let table = ltk_rst::Stringtable::from_reader(&mut Cursor::new(&patched[..])).unwrap();
+        assert_eq!(table.get_key("game_client_quit"), Some("Bye"));
+        assert_eq!(table.get_key("untouched"), Some("Original"));
+        assert_eq!(table.get_key("added_key"), Some("Injected"));
+    }
+
+    #[test]
+    fn apply_rejects_invalid_table() {
+        assert!(plan(&[("k", "v")]).apply(b"not an rst file").is_err());
+    }
+
+    #[test]
+    fn fingerprint_reacts_to_inputs() {
+        let a = plan(&[("key", "value")]);
+        let b = plan(&[("key", "value")]);
+        assert_eq!(a.fingerprint(), b.fingerprint());
+
+        let c = plan(&[("key", "other")]);
+        assert_ne!(a.fingerprint(), c.fingerprint());
+
+        let mut d = plan(&[("key", "value")]);
+        d.locale = "ko_kr".to_string();
+        assert_ne!(a.fingerprint(), d.fingerprint());
+    }
+
+    #[test]
+    fn merge_mod_priority_dominates() {
+        // mods[0] is highest priority; its "default" bucket must beat the
+        // lower-priority mod's locale-specific bucket.
+        let mut mods = vec![
+            strings_mod(
+                "front",
+                vec![layer("base", 0, &[("default", &[("key", "front")])])],
+            ),
+            strings_mod(
+                "back",
+                vec![layer("base", 0, &[("en_us", &[("key", "back")])])],
+            ),
+        ];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"]["key"], "front");
+    }
+
+    #[test]
+    fn merge_canonicalizes_key_case() {
+        // Case variants of a key address the same RST entry (hashing lowercases
+        // field names), so they must collide during the merge for mod priority
+        // to apply — the front mod wins even though the spellings differ.
+        let mut mods = vec![
+            strings_mod(
+                "front",
+                vec![layer(
+                    "base",
+                    0,
+                    &[(
+                        "default",
+                        &[
+                            ("Contested_Key", "front"),
+                            ("F772A83B33773223", "front-hash"),
+                        ],
+                    )],
+                )],
+            ),
+            strings_mod(
+                "back",
+                vec![layer(
+                    "base",
+                    0,
+                    &[(
+                        "default",
+                        &[("contested_key", "back"), ("f772a83b33773223", "back-hash")],
+                    )],
+                )],
+            ),
+        ];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"].len(), 2);
+        assert_eq!(effective["en_us"]["contested_key"], "front");
+        assert_eq!(effective["en_us"]["f772a83b33773223"], "front-hash");
+    }
+
+    #[test]
+    fn merge_keeps_brace_keys_as_named_keys() {
+        // Brace syntax has no special meaning — only bare 16-hex-digit keys are
+        // raw hashes — so a braced key passes through as an ordinary
+        // (lowercased) field name and hashes as a literal string.
+        let mut mods = vec![strings_mod(
+            "m",
+            vec![layer(
+                "base",
+                0,
+                &[(
+                    "default",
+                    &[("{f772a83b33773223}", "braced"), ("kept_key", "kept")],
+                )],
+            )],
+        )];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"].len(), 2);
+        assert_eq!(effective["en_us"]["{f772a83b33773223}"], "braced");
+        assert_eq!(effective["en_us"]["kept_key"], "kept");
+    }
+
+    #[test]
+    fn merge_duplicate_case_variant_buckets_document_order() {
+        // Two buckets whose names differ only in case both match the target
+        // locale; they merge in document order, so the later bucket in the
+        // config ("EN_US" here) wins conflicts. Sorted-name order would pick
+        // "en_US" instead, so this also pins the ordering semantics.
+        let mut mods = vec![strings_mod(
+            "m",
+            vec![layer(
+                "base",
+                0,
+                &[
+                    ("en_US", &[("contested", "first"), ("first_only", "f")]),
+                    ("EN_US", &[("contested", "second"), ("second_only", "s")]),
+                ],
+            )],
+        )];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"]["contested"], "second");
+        assert_eq!(effective["en_us"]["first_only"], "f");
+        assert_eq!(effective["en_us"]["second_only"], "s");
+    }
+
+    #[test]
+    fn merge_locale_beats_default_within_layer() {
+        let mut mods = vec![strings_mod(
+            "m",
+            vec![layer(
+                "base",
+                0,
+                &[
+                    ("default", &[("key", "default-value"), ("other", "kept")]),
+                    ("en_us", &[("key", "locale-value")]),
+                ],
+            )],
+        )];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"]["key"], "locale-value");
+        assert_eq!(effective["en_us"]["other"], "kept");
+    }
+
+    #[test]
+    fn merge_layer_priority_within_mod() {
+        let mut mods = vec![strings_mod(
+            "m",
+            vec![
+                layer("base", 0, &[("default", &[("key", "base")])]),
+                layer("extras", 10, &[("default", &[("key", "extras")])]),
+            ],
+        )];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"]["key"], "extras");
+    }
+
+    #[test]
+    fn merge_skips_disabled_layers_and_empty_keys() {
+        let mut mods = vec![EnabledMod {
+            id: "m".to_string(),
+            content: Box::new(StringsOnlyContent {
+                layers: vec![
+                    layer(
+                        "base",
+                        0,
+                        &[("default", &[("key", "base"), ("", "dropped")])],
+                    ),
+                    layer("extras", 10, &[("default", &[("key", "extras")])]),
+                ],
+            }),
+            enabled_layers: Some(HashSet::new()), // only base stays active
+        }];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"]["key"], "base");
+        assert!(!effective["en_us"].contains_key(""));
+    }
+
+    #[test]
+    fn merge_bucket_keys_case_insensitive() {
+        let mut mods = vec![strings_mod(
+            "m",
+            vec![layer("base", 0, &[("EN_US", &[("key", "value")])])],
+        )];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert_eq!(effective["en_us"]["key"], "value");
+    }
+
+    #[test]
+    fn merge_omits_empty_locales_and_targets() {
+        let mut mods = vec![strings_mod(
+            "m",
+            vec![layer("base", 0, &[("ko_kr", &[("key", "value")])])],
+        )];
+
+        let effective = collect_effective_overrides(&mut mods, &["en_us".to_string()]).unwrap();
+        assert!(effective.is_empty());
+
+        let none = collect_effective_overrides(&mut mods, &[]).unwrap();
+        assert!(none.is_empty());
+    }
+
+    #[test]
+    fn resolve_locales_modes() {
+        let mut wad_index: HashMap<String, Vec<Utf8PathBuf>> = HashMap::new();
+        for name in [
+            "global.en_us.wad.client",
+            "global.ko_kr.wad.client",
+            "global.wad.client",
+            "aatrox.wad.client",
+        ] {
+            wad_index.insert(
+                name.to_string(),
+                vec![Utf8PathBuf::from(format!("DATA/FINAL/{name}"))],
+            );
+        }
+        let game_index = GameIndex {
+            wad_index,
+            hash_index: HashMap::new(),
+            game_fingerprint: 0,
+            subchunktoc_blocked: HashSet::new(),
+        };
+
+        assert!(StringOverrideMode::Disabled
+            .resolve_locales(&game_index)
+            .is_empty());
+        assert_eq!(
+            StringOverrideMode::Locales(vec!["en_US".to_string(), "en_us".to_string()])
+                .resolve_locales(&game_index),
+            vec!["en_us".to_string()]
+        );
+        assert_eq!(
+            StringOverrideMode::AllInstalled.resolve_locales(&game_index),
+            vec!["en_us".to_string(), "ko_kr".to_string()]
+        );
+
+        let blocked = blocked_stringtable_hashes(&game_index);
+        assert_eq!(
+            blocked,
+            HashSet::from([
+                stringtable_chunk_hash("en_us"),
+                stringtable_chunk_hash("ko_kr"),
+            ])
+        );
+    }
+}

--- a/crates/ltk_overlay/src/strings_integration_tests.rs
+++ b/crates/ltk_overlay/src/strings_integration_tests.rs
@@ -1,0 +1,553 @@
+//! End-to-end tests for string override application through the full
+//! `OverlayBuilder::build` pipeline, against a synthetic game directory.
+
+use crate::content::FsModContent;
+use crate::fantome_content::FantomeContent;
+use crate::strings::{stringtable_chunk_hash, StringOverrideMode};
+use crate::{EnabledMod, OverlayBuilder, OverlayStage};
+use camino::{Utf8Path, Utf8PathBuf};
+use ltk_mod_project::{ModProject, ModProjectLayer};
+use ltk_wad::{Wad, WadBuilder, WadChunkBuilder, WadChunkCompression};
+use std::fs;
+use std::io::{Cursor, Write};
+use std::sync::{Arc, Mutex};
+
+fn make_stringtable(entries: &[(&str, &str)]) -> Vec<u8> {
+    let mut table = ltk_rst::Stringtable::new();
+    for (key, value) in entries {
+        table.insert_str(*key, *value);
+    }
+    let mut out = Vec::new();
+    table.to_writer(&mut out).unwrap();
+    out
+}
+
+/// Write `Localized/Global.{locale}.wad.client` into the game dir, containing a
+/// single `data/menu/{locale_lower}/lol.stringtable` chunk.
+fn write_game_wad(game_dir: &Utf8Path, locale: &str, table_bytes: Vec<u8>) {
+    let localized_dir = game_dir.join("DATA").join("FINAL").join("Localized");
+    fs::create_dir_all(localized_dir.as_std_path()).unwrap();
+
+    let chunk_path = format!("data/menu/{}/lol.stringtable", locale.to_ascii_lowercase());
+    let mut cursor = Cursor::new(Vec::new());
+    WadBuilder::default()
+        .with_chunk(
+            WadChunkBuilder::default()
+                .with_path(chunk_path)
+                .with_force_compression(WadChunkCompression::None),
+        )
+        .build_to_writer(&mut cursor, move |_hash, writer| {
+            writer.write_all(&table_bytes)?;
+            Ok(())
+        })
+        .unwrap();
+
+    let wad_path = localized_dir.join(format!("Global.{locale}.wad.client"));
+    fs::write(wad_path.as_std_path(), cursor.into_inner()).unwrap();
+}
+
+fn overlay_stringtable_path(overlay_root: &Utf8Path, locale: &str) -> Utf8PathBuf {
+    overlay_root
+        .join("DATA")
+        .join("FINAL")
+        .join("Localized")
+        .join(format!("Global.{locale}.wad.client"))
+}
+
+/// Mount the patched overlay WAD for `locale` and parse its stringtable chunk.
+fn read_overlay_table(overlay_root: &Utf8Path, locale: &str) -> ltk_rst::Stringtable {
+    let wad_path = overlay_stringtable_path(overlay_root, locale);
+    let file = fs::File::open(wad_path.as_std_path()).unwrap();
+    let mut wad = Wad::mount(file).unwrap();
+    let chunk = *wad
+        .chunks()
+        .get(stringtable_chunk_hash(&locale.to_ascii_lowercase()))
+        .expect("patched WAD must contain the stringtable chunk");
+    let bytes = wad.load_chunk_decompressed(&chunk).unwrap().to_vec();
+    ltk_rst::Stringtable::from_reader(&mut Cursor::new(&bytes[..])).unwrap()
+}
+
+fn string_layer(buckets: &[(&str, &[(&str, &str)])]) -> ModProjectLayer {
+    ModProjectLayer {
+        name: "base".to_string(),
+        display_name: None,
+        priority: 0,
+        description: None,
+        string_overrides: buckets
+            .iter()
+            .map(|(locale, entries)| {
+                (
+                    locale.to_string(),
+                    entries
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                        .collect(),
+                )
+            })
+            .collect(),
+    }
+}
+
+fn write_mod_dir(root: &Utf8Path, name: &str, layers: Vec<ModProjectLayer>) -> Utf8PathBuf {
+    let mod_dir = root.join(name);
+    fs::create_dir_all(mod_dir.join("content").join("base").as_std_path()).unwrap();
+    let project = ModProject {
+        name: name.to_string(),
+        display_name: name.to_string(),
+        version: "1.0.0".to_string(),
+        description: String::new(),
+        authors: vec![],
+        license: None,
+        tags: vec![],
+        champions: vec![],
+        maps: vec![],
+        transformers: vec![],
+        layers,
+        thumbnail: None,
+    };
+    fs::write(
+        mod_dir.join("mod.config.json").as_std_path(),
+        serde_json::to_string_pretty(&project).unwrap(),
+    )
+    .unwrap();
+    mod_dir
+}
+
+fn fs_mod(id: &str, mod_dir: Utf8PathBuf) -> EnabledMod {
+    EnabledMod {
+        id: id.to_string(),
+        content: Box::new(FsModContent::new(mod_dir)),
+        enabled_layers: None,
+    }
+}
+
+struct TestEnv {
+    _tmp: tempfile::TempDir,
+    root: Utf8PathBuf,
+    game_dir: Utf8PathBuf,
+    profile_dir: Utf8PathBuf,
+    overlay_root: Utf8PathBuf,
+}
+
+fn test_env() -> TestEnv {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+    let game_dir = root.join("Game");
+    fs::create_dir_all(game_dir.join("DATA").join("FINAL").as_std_path()).unwrap();
+    let profile_dir = root.join("profile");
+    let overlay_root = profile_dir.join("overlay");
+    TestEnv {
+        _tmp: tmp,
+        root,
+        game_dir,
+        profile_dir,
+        overlay_root,
+    }
+}
+
+#[test]
+fn fs_mod_overrides_patch_game_stringtable() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("game_client_quit", "Quit"), ("untouched", "Original")]),
+    );
+
+    let mod_dir = write_mod_dir(
+        &env.root,
+        "strings-mod",
+        vec![string_layer(&[
+            ("default", &[("game_client_quit", "Bye")]),
+            ("en_us", &[("locale_only", "Locale")]),
+        ])],
+    );
+
+    let stages: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let stages_sink = Arc::clone(&stages);
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::Locales(vec!["en_US".to_string()]))
+    .with_progress(move |progress| {
+        stages_sink
+            .lock()
+            .unwrap()
+            .push(format!("{:?}", progress.stage));
+    });
+    builder.set_enabled_mods(vec![fs_mod("strings-mod", mod_dir)]);
+
+    let result = builder.build().unwrap();
+    assert_eq!(result.wads_built.len(), 1);
+    assert!(result.wads_built[0]
+        .as_str()
+        .ends_with("Global.en_US.wad.client"));
+    assert!(stages
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|s| s == &format!("{:?}", OverlayStage::ApplyingStringOverrides)));
+
+    let table = read_overlay_table(&env.overlay_root, "en_US");
+    assert_eq!(table.get_key("game_client_quit"), Some("Bye"));
+    assert_eq!(table.get_key("locale_only"), Some("Locale"));
+    assert_eq!(table.get_key("untouched"), Some("Original"));
+
+    // Unchanged config -> exact-match skip reuses the patched WAD.
+    let rerun = builder.build().unwrap();
+    assert!(rerun.wads_built.is_empty());
+    assert_eq!(rerun.wads_reused.len(), 1);
+
+    // Disabling string overrides invalidates the skip and drops the WAD.
+    builder = builder.with_string_overrides(StringOverrideMode::Disabled);
+    let disabled = builder.build().unwrap();
+    assert!(disabled.wads_built.is_empty());
+    assert!(!overlay_stringtable_path(&env.overlay_root, "en_US")
+        .as_std_path()
+        .exists());
+}
+
+#[test]
+fn all_installed_mode_patches_every_locale() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("shared_key", "English")]),
+    );
+    write_game_wad(
+        &env.game_dir,
+        "ko_KR",
+        make_stringtable(&[("shared_key", "Korean")]),
+    );
+
+    let mod_dir = write_mod_dir(
+        &env.root,
+        "strings-mod",
+        vec![string_layer(&[
+            ("default", &[("shared_key", "Everywhere")]),
+            ("ko_kr", &[("korean_only", "KR")]),
+        ])],
+    );
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::AllInstalled);
+    builder.set_enabled_mods(vec![fs_mod("strings-mod", mod_dir)]);
+
+    let result = builder.build().unwrap();
+    assert_eq!(result.wads_built.len(), 2);
+
+    let en = read_overlay_table(&env.overlay_root, "en_US");
+    assert_eq!(en.get_key("shared_key"), Some("Everywhere"));
+    assert_eq!(en.get_key("korean_only"), None);
+
+    let ko = read_overlay_table(&env.overlay_root, "ko_KR");
+    assert_eq!(ko.get_key("shared_key"), Some("Everywhere"));
+    assert_eq!(ko.get_key("korean_only"), Some("KR"));
+}
+
+#[test]
+fn mod_shipped_stringtable_is_rejected() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("game_client_quit", "Quit"), ("game_only", "FromGame")]),
+    );
+
+    let mod_dir = write_mod_dir(
+        &env.root,
+        "strings-mod",
+        vec![string_layer(&[(
+            "default",
+            &[("game_client_quit", "Final")],
+        )])],
+    );
+    // The mod also ships a whole replacement stringtable. It must be rejected:
+    // key-level overrides always apply on top of the game's copy.
+    let shipped_dir = mod_dir
+        .join("content")
+        .join("base")
+        .join("Global.en_US.wad.client")
+        .join("data")
+        .join("menu")
+        .join("en_us");
+    fs::create_dir_all(shipped_dir.as_std_path()).unwrap();
+    fs::write(
+        shipped_dir.join("lol.stringtable").as_std_path(),
+        make_stringtable(&[("game_client_quit", "ModQuit"), ("mod_only", "FromMod")]),
+    )
+    .unwrap();
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::Locales(vec!["en_us".to_string()]));
+    builder.set_enabled_mods(vec![fs_mod("strings-mod", mod_dir)]);
+
+    builder.build().unwrap();
+
+    let table = read_overlay_table(&env.overlay_root, "en_US");
+    assert_eq!(table.get_key("game_client_quit"), Some("Final"));
+    assert_eq!(table.get_key("mod_only"), None);
+    assert_eq!(table.get_key("game_only"), Some("FromGame"));
+}
+
+#[test]
+fn mod_shipped_stringtable_is_rejected_even_with_string_patching_disabled() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("game_client_quit", "Quit")]),
+    );
+
+    // The mod ships nothing but a replacement stringtable chunk.
+    let mod_dir = write_mod_dir(&env.root, "strings-mod", vec![string_layer(&[])]);
+    let shipped_dir = mod_dir
+        .join("content")
+        .join("base")
+        .join("Global.en_US.wad.client")
+        .join("data")
+        .join("menu")
+        .join("en_us");
+    fs::create_dir_all(shipped_dir.as_std_path()).unwrap();
+    fs::write(
+        shipped_dir.join("lol.stringtable").as_std_path(),
+        make_stringtable(&[("game_client_quit", "ModQuit")]),
+    )
+    .unwrap();
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    );
+    builder.set_enabled_mods(vec![fs_mod("strings-mod", mod_dir)]);
+
+    let result = builder.build().unwrap();
+    assert!(
+        result.wads_built.is_empty(),
+        "a rejected stringtable chunk must not produce an overlay WAD"
+    );
+    assert!(!overlay_stringtable_path(&env.overlay_root, "en_US")
+        .as_std_path()
+        .exists());
+}
+
+#[test]
+fn corrupt_game_stringtable_is_logged_and_skipped() {
+    let env = test_env();
+    // The game's stringtable chunk is not a valid RST table; patching it must
+    // be logged and skipped without failing the whole overlay build.
+    write_game_wad(&env.game_dir, "en_US", b"not an rst table".to_vec());
+
+    let mod_dir = write_mod_dir(
+        &env.root,
+        "strings-mod",
+        vec![string_layer(&[("default", &[("game_client_quit", "Bye")])])],
+    );
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::Locales(vec!["en_us".to_string()]));
+    builder.set_enabled_mods(vec![fs_mod("strings-mod", mod_dir)]);
+
+    let result = builder.build().unwrap();
+    assert_eq!(result.wads_built.len(), 1);
+
+    // The WAD is still written, with the chunk left as the game shipped it.
+    let wad_path = overlay_stringtable_path(&env.overlay_root, "en_US");
+    let file = fs::File::open(wad_path.as_std_path()).unwrap();
+    let mut wad = Wad::mount(file).unwrap();
+    let chunk = *wad.chunks().get(stringtable_chunk_hash("en_us")).unwrap();
+    assert_eq!(
+        wad.load_chunk_decompressed(&chunk).unwrap().to_vec(),
+        b"not an rst table".to_vec()
+    );
+}
+
+#[test]
+fn fantome_string_overrides_are_applied() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("game_client_quit", "Quit")]),
+    );
+
+    let info = serde_json::json!({
+        "Name": "Fantome Strings",
+        "Author": "Author",
+        "Version": "1.0.0",
+        "Description": "Desc",
+        "Layers": {
+            "base": {
+                "Name": "base",
+                "Priority": 0,
+                "StringOverrides": {
+                    "default": { "game_client_quit": "FantomeBye" }
+                }
+            }
+        }
+    });
+
+    let mut zip = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    zip.start_file("META/info.json", zip::write::SimpleFileOptions::default())
+        .unwrap();
+    zip.write_all(info.to_string().as_bytes()).unwrap();
+    let mut cursor = zip.finish().unwrap();
+    cursor.set_position(0);
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::Locales(vec!["en_us".to_string()]));
+    builder.set_enabled_mods(vec![EnabledMod {
+        id: "fantome-strings".to_string(),
+        content: Box::new(FantomeContent::new(cursor).unwrap()),
+        enabled_layers: None,
+    }]);
+
+    builder.build().unwrap();
+
+    let table = read_overlay_table(&env.overlay_root, "en_US");
+    assert_eq!(table.get_key("game_client_quit"), Some("FantomeBye"));
+}
+
+#[test]
+fn missing_locale_wad_is_skipped_without_failing() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("game_client_quit", "Quit")]),
+    );
+
+    let mod_dir = write_mod_dir(
+        &env.root,
+        "strings-mod",
+        vec![string_layer(&[("default", &[("game_client_quit", "Bye")])])],
+    );
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::Locales(vec![
+        "en_us".to_string(),
+        "zz_zz".to_string(), // not installed
+    ]));
+    builder.set_enabled_mods(vec![fs_mod("strings-mod", mod_dir)]);
+
+    let result = builder.build().unwrap();
+    assert_eq!(result.wads_built.len(), 1);
+    assert_eq!(
+        read_overlay_table(&env.overlay_root, "en_US").get_key("game_client_quit"),
+        Some("Bye")
+    );
+}
+
+#[test]
+fn higher_priority_mod_wins_string_conflicts() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("contested", "Original")]),
+    );
+
+    let front = write_mod_dir(
+        &env.root,
+        "front-mod",
+        vec![string_layer(&[("default", &[("contested", "Front")])])],
+    );
+    let back = write_mod_dir(
+        &env.root,
+        "back-mod",
+        vec![string_layer(&[("en_us", &[("contested", "Back")])])],
+    );
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::Locales(vec!["en_us".to_string()]));
+    builder.set_enabled_mods(vec![fs_mod("front-mod", front), fs_mod("back-mod", back)]);
+
+    builder.build().unwrap();
+
+    // Position 0 has the highest priority, even against a locale-specific
+    // bucket further down the list — mirroring chunk conflict resolution.
+    assert_eq!(
+        read_overlay_table(&env.overlay_root, "en_US").get_key("contested"),
+        Some("Front")
+    );
+}
+
+#[test]
+fn editing_overrides_rebuilds_only_localized_wad() {
+    let env = test_env();
+    write_game_wad(
+        &env.game_dir,
+        "en_US",
+        make_stringtable(&[("game_client_quit", "Quit")]),
+    );
+
+    let mod_dir = write_mod_dir(
+        &env.root,
+        "strings-mod",
+        vec![string_layer(&[(
+            "default",
+            &[("game_client_quit", "First")],
+        )])],
+    );
+
+    let mut builder = OverlayBuilder::new(
+        env.game_dir.clone(),
+        env.overlay_root.clone(),
+        env.profile_dir.clone(),
+    )
+    .with_string_overrides(StringOverrideMode::Locales(vec!["en_us".to_string()]));
+    builder.set_enabled_mods(vec![fs_mod("strings-mod", mod_dir.clone())]);
+    builder.build().unwrap();
+
+    // Edit the override value; the state's mod list still matches, but the
+    // per-WAD fingerprint (derived from the merged override map) changed.
+    write_mod_dir(
+        &env.root,
+        "strings-mod",
+        vec![string_layer(&[(
+            "default",
+            &[("game_client_quit", "Second")],
+        )])],
+    );
+
+    // The exact-match skip keys on the enabled-mod id list, so an in-place
+    // config edit needs a changed id (or a forced rebuild) to get past it —
+    // same as any other in-place content edit. With the skip bypassed, the
+    // per-WAD fingerprint (derived from the merged override map) must pick up
+    // the change and rebuild exactly the localized WAD.
+    builder.set_enabled_mods(vec![fs_mod("strings-mod-v2", mod_dir)]);
+    let result = builder.build().unwrap();
+    assert_eq!(result.wads_built.len(), 1);
+    assert_eq!(
+        read_overlay_table(&env.overlay_root, "en_US").get_key("game_client_quit"),
+        Some("Second")
+    );
+}


### PR DESCRIPTION
Implements the string override system (#97): per-layer, per-locale string overrides declared in mod metadata are now merged across all enabled mods and applied on top of the game's data/menu/{locale}/lol.stringtable via ltk_rst, producing a patched chunk in the Localized/Global.{locale} overlay WAD.

- New strings module: StringOverrideMode (Disabled / Locales / AllInstalled), merge semantics mirroring chunk conflict resolution (mod order > layer priority > locale bucket over "default"), and {hex} raw-hash key support for entries with unknown plaintext names.
- Patches are planned in pass 1 as synthetic override meta entries (fingerprinted from the merged map) and generated lazily in pass 2, so unchanged overrides never re-read the game stringtable on incremental builds. A mod-shipped whole stringtable becomes the patch base.
- OverlayState now records the target locales and includes them in the exact-match comparison (breaking: OverlayState::new / matches signatures).
- FantomeContent::mod_project now preserves declared layers and their StringOverrides instead of discarding them (#84 parity).
- FsModContent::content_fingerprint now covers mod.config.json/.toml, since string overrides live in the config rather than content/.

ltk_rst is consumed from the league-toolkit rst-api-rework branch (PR #138) until it ships on crates.io as 0.2.0.

Closes #97