### PR TITLE
feat: add embedded hashtable support

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,164 @@
+# League Mod Toolkit
+
+Tools and libraries for building, packaging and distributing League of Legends mods. A mod is
+authored as a **mod project** and shipped as a **package**; the words below are the ones the
+crates, the configs and the wiki all use for the same things.
+
+## Language
+
+### Mod shape
+
+**Mod project**:
+A mod in its authored, unpacked form: a manifest at the root and content laid out per layer.
+_Avoid_: workspace, mod folder, source mod
+
+**Layer**:
+A named, prioritized slice of a mod's content. Every project has `base`; higher priorities
+override lower ones when an overlay is built.
+_Avoid_: variant, overlay, patch
+
+**WAD target**:
+The `.wad.client` archive a piece of content belongs in, named by a directory inside a layer.
+_Avoid_: WAD file, archive target
+
+**Chunk**:
+One file inside a WAD, addressed by the hash of its path rather than by the path.
+_Avoid_: entry, asset, file
+
+**Chunk path**:
+A chunk's path *within* its WAD target. Excludes the layer and the `.wad.client` directory.
+_Avoid_: asset path, relative path
+
+**Container**:
+Any of the three shapes a mod's names can travel in: a `.fantome` archive, a mod project
+directory, or a `.modpkg` package. Used when a rule holds for all three.
+_Avoid_: format, package type
+
+### Names and hashing
+
+**Embedded hashtable**:
+A table of names a mod carries *inside itself*, covering the names that mod introduces. Travels
+with the content it names.
+_Avoid_: bundled hashtable, mod hashtable, local hashtable
+
+**Community hashtable**:
+The ambient CommunityDragon name lists a tool ships or downloads separately, covering names the
+game introduces. Never embedded in a mod.
+_Avoid_: global hashtable, CDragon table, the hashtables
+
+**Hashtable file**:
+The plain-text payload of one table: one name per line, printable ASCII, no hash column.
+_Avoid_: hash file, names file, wordlist
+
+**Manifest entry**:
+The declaration that gives one hashtable file its meaning - where it lives, its category, its
+algorithm, and its key width. A table a manifest does not declare does not exist.
+_Avoid_: table header, table config, registration
+
+**Category**:
+The lookup domain a table's names belong to: `game`, `binentries` or `binhashes`. Fixes which
+hash space a name is resolved in.
+_Avoid_: kind, namespace, table type
+
+**Canonical name**:
+A name after ASCII-lowercasing - the exact bytes that get hashed. Two names differing only in
+case share one canonical name.
+_Avoid_: normalized name, lowercased path
+
+**Display casing**:
+The casing a name is written in - both in a hashtable file and in the path a package stores.
+Carried for humans; never hashed.
+_Avoid_: original casing, pretty name
+
+**Stored path**:
+A chunk path spelled as its author wrote it. What a package holds and what an extraction names
+files by. Hashing lowercases it first, so casing never changes a chunk's identity.
+_Avoid_: display path, real path, original path
+
+**Key**:
+A name's hash truncated to the manifest entry's declared width. Duplicates and collisions are
+both judged on keys, never on full hashes.
+_Avoid_: hash, truncated hash, id
+
+**Duplicate**:
+The same canonical name appearing twice in a category. A writer must not emit one; a reader
+keeps the first.
+_Avoid_: repeat, collision
+
+**Collision**:
+Two *different* canonical names sharing one key. A packing error, not a duplicate.
+_Avoid_: clash, conflict, duplicate
+
+**Trimmed table**:
+A `game` table that deliberately omits names a reader can recover elsewhere - one the package
+already stores as a chunk, or one the community hashtables hold. Only `game` is ever trimmed.
+_Avoid_: partial table, minimal table, sparse table
+
+**Hex name**:
+A key rendered as lowercase zero-padded hex - the placeholder a chunk lands under when nothing
+names it, and the on-disk marker that a name is missing.
+_Avoid_: hash name, raw name, fallback name
+
+### Library storage
+
+**Projectify**:
+Turning a mod held as an archive into an unpacked mod project directory. A mod can be stored either
+way; projectifying changes the storage shape, never the mod's identity.
+_Avoid_: unpack, extract, convert, explode
+
+### Preserving names
+
+**Harvest**:
+Reading a mod's names out of the places they currently survive - its on-disk chunk paths and the
+strings inside its own bins - so they can be written into an embedded hashtable.
+_Avoid_: scan, extract, recover, generate
+
+**Rewrite**:
+Writing a mod's harvested names back into its own archive, every other entry untouched. Runs only
+when the harvest found a name the archive does not already declare.
+_Avoid_: repack, resave, update
+
+**Preserve**:
+The whole motion the manager calls at import: harvest a mod's names, then rewrite them into the
+mod's container. Harvest is the reading half; rewrite is the writing half.
+_Avoid_: fix, import-fix, process
+
+**Exclusions**:
+The names a harvest leaves out of a table because a reader can recover them without the mod's
+help - in practice, the community hashtables. Handed in by the caller, never assumed.
+_Avoid_: filter, skip list, blacklist
+
+**Unharvestable name**:
+A name that survives nowhere the harvest can read: its chunk is hex-named and no bin still spells
+it out. Counted and reported, never guessed at.
+_Avoid_: lost name, missing name, unknown name
+
+**Harvest report**:
+A preserve's account of itself: whether the mod was rewritten and how many names were
+unharvestable. What separates a mod that harvested cleanly from one that did not.
+_Avoid_: result, summary, stats
+
+**Covered mod**:
+A mod whose names the community hashtables and its own stored paths already fully account for.
+Preserving one adds nothing, so its archive is never touched.
+_Avoid_: clean mod, known mod, no-op mod
+
+**Unrepresentable path**:
+A real chunk path no filesystem can hold: over the length limit, a reserved device name, a
+trailing dot or space, or a case-only clash with a sibling. Its name survives only in a table.
+_Avoid_: invalid path, bad path, illegal path
+
+**Escape hatch**:
+The convention that pairs an unrepresentable path with a hex-named file at the WAD root, so the
+content lands on disk and the name lands in the `game` table.
+_Avoid_: fallback, workaround
+
+**File property**:
+A `.bin` property whose value is the xxh64 of a path - the same hash space chunks are addressed
+in, which is why one `game` table answers both.
+_Avoid_: path property, file ref
+
+**Hash property**:
+A `.bin` property whose value is the fnv1a_32 of a string. Recoverable only through a
+`binhashes` table.
+_Avoid_: string hash, hashed string

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ version = "0.9.0"
 dependencies = [
  "camino",
  "indexmap",
+ "ltk_hashtable",
  "ltk_wad",
  "serde",
  "serde_json",
@@ -1344,6 +1345,18 @@ checksum = "ada44666d233f89786fdfd6784346a140ddfc7c31d31ac23dfa7b066f9fbe41b"
 dependencies = [
  "byteorder",
  "xxhash-rust",
+]
+
+[[package]]
+name = "ltk_hashtable"
+version = "0.1.0"
+dependencies = [
+ "camino",
+ "ltk_hash",
+ "ltk_wad",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1378,6 +1391,7 @@ dependencies = [
  "image",
  "indexmap",
  "ltk_fantome",
+ "ltk_hashtable",
  "ltk_modpkg",
  "ltk_wad",
  "semver",
@@ -1399,6 +1413,7 @@ dependencies = [
  "byteorder",
  "indexmap",
  "itertools",
+ "ltk_hashtable",
  "ltk_io_ext",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 members = [
     "crates/league-mod",
     "crates/ltk_fantome",
+    "crates/ltk_hashtable",
     "crates/ltk_mod_core",
     "crates/ltk_modpkg",
     "crates/ltk_mod_project",
@@ -13,5 +14,6 @@ members = [
 [workspace.dependencies]
 camino = "1.1"
 indexmap = { version = "2", features = ["serde"] }
+ltk_hash = "0.4"
 ltk_wad = "0.5.3"
 sysinfo = "0.32"

--- a/crates/league-mod/src/commands/init.rs
+++ b/crates/league-mod/src/commands/init.rs
@@ -105,6 +105,7 @@ fn create_default_mod_project(name: Option<String>, display_name: Option<String>
         transformers: vec![],
         layers: ltk_mod_project::ModProjectLayer::default_table(),
         thumbnail: None,
+        hashtables: vec![],
     }
 }
 

--- a/crates/league-mod/src/commands/pack.rs
+++ b/crates/league-mod/src/commands/pack.rs
@@ -78,9 +78,19 @@ fn pack_to_modpkg(
     let file = File::create(&output_path).into_diagnostic()?;
     let writer = BufWriter::new(file);
 
-    ProjectPacker::new(mod_project, project_root.to_owned())
+    let report = ProjectPacker::new(mod_project, project_root.to_owned())
         .pack(ModpkgFormat::new(writer))
         .map_err(convert_pack_error)?;
+
+    // A silent trim and an empty table look identical from outside, and only
+    // one of them is correct.
+    if report.trimmed_game_names() > 0 {
+        println_pad!(
+            "{} {} game hashtable name(s) already recovered by the package's own chunk paths",
+            "✂️  Trimmed:".bright_yellow(),
+            report.trimmed_game_names().to_string().bright_cyan().bold()
+        );
+    }
 
     println_pad!(
         "{}\n{} {}",

--- a/crates/ltk_fantome/src/error.rs
+++ b/crates/ltk_fantome/src/error.rs
@@ -40,6 +40,22 @@ pub enum FantomeExtractError {
     #[error("Missing info.json metadata file")]
     MissingMetadata,
 
+    /// The manifest declares a hashtable file the archive does not hold.
+    #[error("The manifest declares {path}, but the archive holds no such entry")]
+    MissingHashtable {
+        /// The declared path, relative to the archive root.
+        path: String,
+    },
+
+    /// A declared hashtable file does not fit the table grammar.
+    #[error("Failed to read the hashtable at {path}")]
+    Hashtable {
+        /// The declared path, relative to the archive root.
+        path: String,
+        #[source]
+        source: ltk_hashtable::HashtableReadError,
+    },
+
     /// An entry names a path that leaves the directory it would be extracted
     /// to, so extracting the archive would write outside it.
     ///

--- a/crates/ltk_fantome/src/lib.rs
+++ b/crates/ltk_fantome/src/lib.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 
 pub mod error;
 mod reader;
+mod rewrite;
 mod writer;
 
 pub use error::{FantomeExtractError, FantomeWriteError};
@@ -21,6 +22,7 @@ pub use error::{FantomeExtractError, FantomeWriteError};
 /// bins. [`NamingPolicy`] decides what becomes of a chunk two paths claim.
 pub use ltk_wad::{NamingPolicy, NoResolver, PathResolver};
 pub use reader::{FantomeEntry, FantomeReader, WadExtractOptions, WadProgress, classify_entry};
+pub use rewrite::{FantomeRewriteError, RewriteOutcome, add_hashtables};
 pub use writer::FantomeWriter;
 
 /// Fantome metadata structure that goes into info.json
@@ -56,6 +58,68 @@ pub struct FantomeInfo {
     /// Per-layer metadata including string overrides.
     #[serde(rename = "Layers", default, skip_serializing_if = "HashMap::is_empty")]
     pub layers: HashMap<String, FantomeLayerInfo>,
+    /// The embedded hashtables the archive declares.
+    ///
+    /// The manifest is authoritative: a `META/hashes/` entry no manifest
+    /// entry declares does not exist for lookup. Absent from archives written
+    /// before the standard, and omitted when empty so an archive without
+    /// tables serializes byte-identically to one written before this field.
+    #[serde(rename = "Hashtables", default, skip_serializing_if = "Vec::is_empty")]
+    pub hashtables: Vec<FantomeHashtable>,
+    /// Fields this crate does not know, carried verbatim.
+    ///
+    /// `info.json` is shared ground: other tools extend it, and the archive
+    /// rewrite reserializes it. Dropping what we cannot name would make this
+    /// crate the older tool that silently strips a newer one's data.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// One `Hashtables` manifest entry in a Fantome info.json.
+///
+/// The fantome spelling of `ltk_hashtable`'s `HashtableEntry`: PascalCase
+/// keys, `Path` relative to the archive root. Convert with
+/// [`FantomeHashtable::to_entry`] and [`FantomeHashtable::from_entry`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct FantomeHashtable {
+    /// Where the table file lives, relative to the archive root.
+    #[serde(rename = "Path")]
+    pub path: String,
+    /// The lookup domain of the table's names.
+    #[serde(rename = "Category")]
+    pub category: ltk_hashtable::Category,
+    /// The hash function keying the table's names.
+    #[serde(rename = "Algorithm")]
+    pub algorithm: ltk_hashtable::Algorithm,
+    /// The declared key width in bits.
+    #[serde(rename = "Bits")]
+    pub bits: u8,
+}
+
+impl FantomeHashtable {
+    /// The entry as `ltk_hashtable`'s domain type.
+    ///
+    /// `None` when `Bits` declares a width no key can have; the standard
+    /// requires `1..=64`.
+    pub fn to_entry(&self) -> Option<ltk_hashtable::HashtableEntry> {
+        let width = ltk_hashtable::KeyWidth::new(self.bits)?;
+        Some(ltk_hashtable::HashtableEntry::new(
+            self.path.as_str(),
+            self.category.clone(),
+            self.algorithm.clone(),
+            width,
+        ))
+    }
+
+    /// Spell a domain entry the fantome way.
+    pub fn from_entry(entry: &ltk_hashtable::HashtableEntry) -> Self {
+        Self {
+            path: entry.path().to_string(),
+            category: entry.category().clone(),
+            algorithm: entry.algorithm().clone(),
+            bits: entry.width().bits(),
+        }
+    }
 }
 
 /// The license declaration in a Fantome info.json.

--- a/crates/ltk_fantome/src/reader.rs
+++ b/crates/ltk_fantome/src/reader.rs
@@ -222,6 +222,95 @@ impl<R: Read + Seek> FantomeReader<R> {
         Ok(info)
     }
 
+    /// Read the hashtables the manifest declares - and only those.
+    ///
+    /// An entry in `META/hashes/` that no manifest entry declares is not a
+    /// table and is not read; the manifest is authoritative. An entry whose
+    /// declared width is not one a key can have is skipped rather than
+    /// refused - it still travels with the archive, it just cannot answer a
+    /// lookup here.
+    ///
+    /// The pairs feed `ltk_hashtable::HashtableSet::build` as they are.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the archive cannot be read, a declared table file
+    /// is missing, or one does not fit the table grammar.
+    pub fn read_hashtables(
+        &mut self,
+    ) -> Result<Vec<(ltk_hashtable::HashtableEntry, ltk_hashtable::Hashtable)>, FantomeExtractError>
+    {
+        let info = self.read_info()?;
+        let mut tables = Vec::new();
+        for manifest in &info.hashtables {
+            let Some(entry) = manifest.to_entry() else {
+                continue;
+            };
+            // Case-insensitive like every other entry lookup here: archives
+            // in the wild spell `META/` in any casing.
+            let index = (0..self.archive.len()).find(|i| {
+                self.archive
+                    .by_index(*i)
+                    .is_ok_and(|file| file.name().eq_ignore_ascii_case(&manifest.path))
+            });
+            let Some(index) = index else {
+                return Err(FantomeExtractError::MissingHashtable {
+                    path: manifest.path.clone(),
+                });
+            };
+            let content = read_entry(&mut self.archive.by_index(index)?)?;
+            let table =
+                ltk_hashtable::Hashtable::from_reader(content.as_slice()).map_err(|source| {
+                    FantomeExtractError::Hashtable {
+                        path: manifest.path.clone(),
+                        source,
+                    }
+                })?;
+            tables.push((entry, table));
+        }
+        Ok(tables)
+    }
+
+    /// Read the bytes of the packed WAD stored as the single entry
+    /// `WAD/{wad_name}`, or `None` when the archive holds no such entry.
+    ///
+    /// The name is matched case-insensitively, like every entry lookup here.
+    /// A WAD stored as a directory of files has no packed bytes and answers
+    /// `None`; its files are what [`classify_entry`] calls
+    /// [`WadFile`](FantomeEntry::WadFile). Like every entry read, the stored
+    /// CRC32 is deliberately not checked.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry cannot be read.
+    pub fn read_packed_wad(
+        &mut self,
+        wad_name: &str,
+    ) -> Result<Option<Vec<u8>>, FantomeExtractError> {
+        let index = (0..self.archive.len()).find(|i| {
+            self.archive.by_index(*i).is_ok_and(|file| {
+                matches!(
+                    classify_entry(file.name()),
+                    Some(FantomeEntry::PackedWad(name)) if name.eq_ignore_ascii_case(wad_name)
+                )
+            })
+        });
+        let Some(index) = index else {
+            return Ok(None);
+        };
+        Ok(Some(read_entry(&mut self.archive.by_index(index)?)?))
+    }
+
+    /// How many entries the archive holds, directory records included.
+    pub(crate) fn entry_count(&self) -> usize {
+        self.archive.len()
+    }
+
+    /// The inner zip archive, for the rewrite's raw entry copies.
+    pub(crate) fn zip_archive_mut(&mut self) -> &mut ZipArchive<R> {
+        &mut self.archive
+    }
+
     /// The archive's entry names, in archive order.
     ///
     /// Only the entry table is read, so this costs no decompression. Pair it
@@ -485,6 +574,14 @@ pub enum FantomeEntry<'a> {
     Image,
     /// `META/info.json`, the archive's metadata.
     Info,
+    /// A file under `META/hashes/`, at this path relative to the prefix.
+    ///
+    /// This is placement, not lookup: it says where the file would land on
+    /// disk, which is what a caller preflighting paths needs. Whether the
+    /// file is a hashtable is the manifest's to say - only
+    /// [`FantomeReader::read_hashtables`], which reads the manifest, ever
+    /// produces a table for lookup.
+    Hashtable(&'a str),
 }
 
 /// Where the file named `entry_name` belongs.
@@ -515,6 +612,10 @@ pub fn classify_entry(entry_name: &str) -> Option<FantomeEntry<'_>> {
 
     if let Some(relative_path) = strip_prefix_ci(entry_name, "RAW/") {
         return (!relative_path.is_empty()).then_some(FantomeEntry::Raw(relative_path));
+    }
+
+    if let Some(relative_path) = strip_prefix_ci(entry_name, "META/hashes/") {
+        return (!relative_path.is_empty()).then_some(FantomeEntry::Hashtable(relative_path));
     }
 
     if let Some(target) = license_entry_target(entry_name) {

--- a/crates/ltk_fantome/src/reader/tests.rs
+++ b/crates/ltk_fantome/src/reader/tests.rs
@@ -325,6 +325,8 @@ fn writer_reader_round_trip() {
         champions: vec![],
         maps: vec![],
         layers: Default::default(),
+        hashtables: vec![],
+        extra: Default::default(),
     };
 
     let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));

--- a/crates/ltk_fantome/src/rewrite.rs
+++ b/crates/ltk_fantome/src/rewrite.rs
@@ -1,0 +1,210 @@
+//! [`add_hashtables`]: merge harvested names into an archive, in one pass.
+//!
+//! The rewrite raw-copies every entry it does not itself replace, so the
+//! mismatched CRC32 values Fantome tools in the wild write are carried
+//! through rather than recomputed - which is what [`FantomeReader`] already
+//! expects, since it deliberately bypasses the check - and no entry is ever
+//! decompressed or recompressed.
+
+use std::collections::HashSet;
+use std::io::{Read, Seek, Write};
+
+use ltk_hashtable::{Category, Hashtable, HashtableSet, Key};
+
+use crate::{
+    FantomeExtractError, FantomeHashtable, FantomeReader, FantomeWriteError, FantomeWriter,
+};
+
+/// What a rewrite did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RewriteOutcome {
+    /// Every harvested name was already declared; nothing was written to the
+    /// sink.
+    Unchanged,
+    /// The sink holds the rewritten archive.
+    Rewritten {
+        /// How many names the archive gained.
+        names_added: usize,
+    },
+}
+
+/// Failure to rewrite an archive.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum FantomeRewriteError {
+    /// The source archive could not be read.
+    #[error(transparent)]
+    Read(#[from] FantomeExtractError),
+
+    /// The rewritten archive could not be written.
+    #[error(transparent)]
+    Write(#[from] FantomeWriteError),
+}
+
+/// The first conventional table path for `category` that `taken` does not
+/// hold. The `{category}.hashes.txt` name is a convention, not a rule, so a
+/// qualifier is added whenever the plain name would land on an entry that is
+/// already someone's.
+fn free_table_path(category: &Category, taken: &HashSet<String>) -> String {
+    let mut candidates =
+        std::iter::once(format!("META/hashes/{category}.hashes.txt")).chain((1..).map(|attempt| {
+            match attempt {
+                1 => format!("META/hashes/{category}.harvested.hashes.txt"),
+                n => format!("META/hashes/{category}.harvested{n}.hashes.txt"),
+            }
+        }));
+    candidates
+        .find(|candidate| !taken.contains(&candidate.to_ascii_lowercase()))
+        .expect("the candidate sequence is unbounded")
+}
+
+/// One table file the rewrite will emit, and the manifest entry declaring it.
+struct PlannedTable {
+    manifest: FantomeHashtable,
+    table: Hashtable,
+}
+
+/// Merge `harvested` names into the archive `reader` holds, writing the
+/// result to `sink`.
+///
+/// The merge adds and never replaces: a name whose key an archive's declared
+/// tables already resolve is not added again, an existing manifest gains
+/// entries rather than losing any, and an existing table file gains the
+/// category's new names in `LC_ALL=C` order while keeping every name it
+/// already held. Every other entry is raw-copied byte-for-byte, wrong CRC32
+/// values included.
+///
+/// When nothing is genuinely new the sink is left untouched and
+/// [`RewriteOutcome::Unchanged`] comes back - deciding costs one read, so a
+/// covered mod is never rewritten and a rerun is a no-op. The caller owns
+/// where the sink lives; a rewrite over a file the user did not ask to lose
+/// belongs behind a temp-file-and-rename.
+///
+/// # Errors
+///
+/// Returns an error if the source archive cannot be read or the rewritten
+/// archive cannot be written. Nothing is written on a read failure.
+pub fn add_hashtables<R: Read + Seek, W: Write + Seek>(
+    reader: &mut FantomeReader<R>,
+    sink: W,
+    harvested: &[(Category, Hashtable)],
+) -> Result<RewriteOutcome, FantomeRewriteError> {
+    let mut info = reader.read_info()?;
+    let declared = reader.read_hashtables()?;
+    let resolved = HashtableSet::build(declared.iter().cloned());
+
+    // Paths a new entry must not land on: everything the manifest already
+    // declares - the entries this tool cannot read included, since unknown is
+    // not disposable - and every entry the archive holds.
+    let mut taken: HashSet<String> = info
+        .hashtables
+        .iter()
+        .map(|manifest| manifest.path.to_ascii_lowercase())
+        .collect();
+    taken.extend(reader.entry_names().map(str::to_ascii_lowercase));
+
+    let mut plans: Vec<PlannedTable> = Vec::new();
+    let mut names_added = 0;
+
+    for (category, table) in harvested {
+        // The shape new keys are judged in: the first declared entry of the
+        // category whose keys are computable, else the registry's shape. A
+        // category with neither is skipped - its keys mean nothing here.
+        let merge_target = info.hashtables.iter().find(|manifest| {
+            manifest.category == *category
+                && manifest
+                    .to_entry()
+                    .is_some_and(|entry| Key::of("", entry.algorithm(), entry.width()).is_some())
+        });
+        let (algorithm, width) = match merge_target {
+            Some(manifest) => {
+                let entry = manifest.to_entry().expect("merge target validated above");
+                (entry.algorithm().clone(), entry.width())
+            }
+            None => match category.default_shape() {
+                Some(shape) => shape,
+                None => continue,
+            },
+        };
+
+        let mut fresh_keys = HashSet::new();
+        let fresh: Vec<&str> = table
+            .names()
+            .filter(|name| {
+                let Some(key) = Key::of(name, &algorithm, width) else {
+                    return false;
+                };
+                resolved.resolve(category, key).is_none() && fresh_keys.insert(key)
+            })
+            .collect();
+        if fresh.is_empty() {
+            continue;
+        }
+        names_added += fresh.len();
+
+        let (manifest, base) = match merge_target {
+            Some(manifest) => {
+                let base = declared
+                    .iter()
+                    .find(|(entry, _)| entry.path() == manifest.path.as_str())
+                    .map(|(_, table)| table.clone())
+                    .unwrap_or_default();
+                (manifest.clone(), base)
+            }
+            None => {
+                let path = free_table_path(category, &taken);
+                taken.insert(path.to_ascii_lowercase());
+                let manifest = FantomeHashtable {
+                    path,
+                    category: category.clone(),
+                    algorithm: algorithm.clone(),
+                    bits: width.bits(),
+                };
+                info.hashtables.push(manifest.clone());
+                (manifest, Hashtable::default())
+            }
+        };
+
+        let mut merged = Hashtable::from_names(base.names().chain(fresh.iter().copied()))
+            .expect("every name came out of a validated table");
+        merged.sort();
+        plans.push(PlannedTable {
+            manifest,
+            table: merged,
+        });
+    }
+
+    if plans.is_empty() {
+        return Ok(RewriteOutcome::Unchanged);
+    }
+
+    let mut writer = FantomeWriter::new(sink);
+    writer.write_info(&info)?;
+
+    let mut replaced: HashSet<String> = plans
+        .iter()
+        .map(|plan| plan.manifest.path.to_ascii_lowercase())
+        .collect();
+    replaced.insert("meta/info.json".to_owned());
+
+    for plan in &plans {
+        writer.write_hashtable(&plan.manifest, &plan.table)?;
+    }
+
+    for index in 0..reader.entry_count() {
+        let file = reader
+            .zip_archive_mut()
+            .by_index_raw(index)
+            .map_err(FantomeExtractError::from)?;
+        if replaced.contains(&file.name().to_ascii_lowercase()) {
+            continue;
+        }
+        writer
+            .zip_mut()
+            .raw_copy_file(file)
+            .map_err(FantomeWriteError::from)?;
+    }
+    writer.finish()?;
+
+    Ok(RewriteOutcome::Rewritten { names_added })
+}

--- a/crates/ltk_fantome/src/tests.rs
+++ b/crates/ltk_fantome/src/tests.rs
@@ -11,6 +11,8 @@ fn info_json(license: Option<FantomeLicense>) -> serde_json::Value {
         champions: vec![],
         maps: vec![],
         layers: HashMap::new(),
+        hashtables: vec![],
+        extra: Default::default(),
     };
     serde_json::to_value(&info).unwrap()
 }
@@ -77,4 +79,498 @@ fn custom_license_rejects_unknown_field() {
         serde_json::from_str::<FantomeInfo>(typoed).is_err(),
         "a misspelled license key must not parse as a URL-less license"
     );
+}
+
+#[test]
+fn info_json_round_trips_the_hashtables_manifest() {
+    let json = serde_json::json!({
+        "Name": "Old Summoners Rift",
+        "Author": "TheKillerey, Crauzer",
+        "Version": "1.0.0",
+        "Description": "Brings back the classic Summoners Rift map",
+        "Hashtables": [
+            {
+                "Path": "META/hashes/game.hashes.txt",
+                "Category": "game",
+                "Algorithm": "xxh64",
+                "Bits": 64
+            },
+            {
+                "Path": "META/hashes/binentries.hashes.txt",
+                "Category": "binentries",
+                "Algorithm": "fnv1a_32",
+                "Bits": 32
+            }
+        ]
+    });
+
+    let info: FantomeInfo = serde_json::from_value(json.clone()).unwrap();
+    assert_eq!(info.hashtables.len(), 2);
+    assert_eq!(serde_json::to_value(&info).unwrap(), json);
+}
+
+#[test]
+fn info_json_without_hashtables_serializes_without_the_field() {
+    let info = FantomeInfo {
+        name: "A mod".to_owned(),
+        ..Default::default()
+    };
+    let value = serde_json::to_value(&info).unwrap();
+    assert!(value.get("Hashtables").is_none());
+
+    // And the archive entry itself carries no trace of the new fields, so an
+    // archive without tables is byte-identical to one written before them.
+    use std::io::{Cursor, Read as _};
+
+    use crate::FantomeWriter;
+
+    let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));
+    writer.write_info(&info).unwrap();
+    let bytes = writer.finish().unwrap().into_inner();
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).unwrap();
+    let mut entry_text = String::new();
+    archive
+        .by_name("META/info.json")
+        .unwrap()
+        .read_to_string(&mut entry_text)
+        .unwrap();
+    assert!(!entry_text.contains("Hashtables"));
+    assert!(!entry_text.contains("extra"));
+}
+
+#[test]
+fn a_hashtable_round_trips_through_the_archive() {
+    use std::io::Cursor;
+
+    use crate::{FantomeReader, FantomeWriter};
+
+    let manifest = FantomeHashtable {
+        path: "META/hashes/game.hashes.txt".to_owned(),
+        category: ltk_hashtable::Category::Game,
+        algorithm: ltk_hashtable::Algorithm::Xxh64,
+        bits: 64,
+    };
+    let table = ltk_hashtable::Hashtable::from_reader(
+        &b"ASSETS/Custom/One.tex\nassets/custom/two.bin\n"[..],
+    )
+    .unwrap();
+
+    let info = FantomeInfo {
+        name: "Tabled".to_owned(),
+        hashtables: vec![manifest.clone()],
+        ..Default::default()
+    };
+
+    let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));
+    writer.write_info(&info).unwrap();
+    writer.write_hashtable(&manifest, &table).unwrap();
+    let archive = writer.finish().unwrap().into_inner();
+
+    let mut reader = FantomeReader::new(Cursor::new(archive)).unwrap();
+    let tables = reader.read_hashtables().unwrap();
+    assert_eq!(tables.len(), 1);
+    let (entry, read_back) = &tables[0];
+    assert_eq!(entry.path(), "META/hashes/game.hashes.txt");
+    assert_eq!(*entry.category(), ltk_hashtable::Category::Game);
+    assert_eq!(read_back, &table);
+}
+
+#[test]
+fn an_undeclared_hashes_entry_is_not_read() {
+    use std::io::Cursor;
+
+    use crate::{FantomeReader, FantomeWriter};
+
+    // The file exists in the archive, but no manifest entry declares it.
+    let undeclared = FantomeHashtable {
+        path: "META/hashes/game.hashes.txt".to_owned(),
+        category: ltk_hashtable::Category::Game,
+        algorithm: ltk_hashtable::Algorithm::Xxh64,
+        bits: 64,
+    };
+    let table = ltk_hashtable::Hashtable::from_reader(&b"assets/custom/one.tex\n"[..]).unwrap();
+
+    let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));
+    writer
+        .write_info(&FantomeInfo {
+            name: "Undeclared".to_owned(),
+            ..Default::default()
+        })
+        .unwrap();
+    writer.write_hashtable(&undeclared, &table).unwrap();
+    let archive = writer.finish().unwrap().into_inner();
+
+    let mut reader = FantomeReader::new(Cursor::new(archive)).unwrap();
+    assert!(reader.read_hashtables().unwrap().is_empty());
+}
+
+#[test]
+fn a_meta_hashes_entry_classifies_as_a_hashtable() {
+    use crate::{FantomeEntry, classify_entry};
+
+    assert_eq!(
+        classify_entry("META/hashes/game.hashes.txt"),
+        Some(FantomeEntry::Hashtable("game.hashes.txt"))
+    );
+    assert_eq!(
+        classify_entry("meta/HASHES/game.imported.hashes.txt"),
+        Some(FantomeEntry::Hashtable("game.imported.hashes.txt"))
+    );
+    // A directory entry is not a file, and the bare directory places nothing.
+    assert_eq!(classify_entry("META/hashes/"), None);
+}
+
+// The rewrite: raw-copy every entry, merge in harvested names, never touch
+// what is already there.
+
+mod rewrite {
+    use std::io::Cursor;
+
+    use ltk_hashtable::{Category, Hashtable};
+
+    use crate::{
+        FantomeInfo, FantomeReader, FantomeWriter, RewriteOutcome, WadExtractOptions,
+        add_hashtables,
+    };
+
+    /// An archive holding `META/info.json` (written last) and one WAD file
+    /// entry (written first, so its local header sits at offset 0), with the
+    /// WAD entry's CRC32 overwritten the way tools in the wild do.
+    fn archive_with_wrong_crc(info: &FantomeInfo, payload: &[u8]) -> Vec<u8> {
+        let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));
+        writer
+            .write_wad_entry("Aatrox.wad.client", "data/x.bin", &mut &payload[..])
+            .unwrap();
+        writer.write_info(info).unwrap();
+        let mut bytes = writer.finish().unwrap().into_inner();
+
+        // The first local file header starts at offset 0; its CRC32 field is
+        // bytes 14..18. Stamp the same wrong value over every occurrence so
+        // the central directory copy changes too.
+        let real_crc: [u8; 4] = bytes[14..18].try_into().unwrap();
+        let wrong_crc = [0xEF, 0xBE, 0xAD, 0xDE];
+        assert_ne!(real_crc, wrong_crc);
+        let mut i = 0;
+        while i + 4 <= bytes.len() {
+            if bytes[i..i + 4] == real_crc {
+                bytes[i..i + 4].copy_from_slice(&wrong_crc);
+            }
+            i += 1;
+        }
+        bytes
+    }
+
+    #[test]
+    fn a_rewrite_adds_its_tables_and_raw_copies_every_entry() {
+        let payload = b"wad payload bytes";
+        let bytes = archive_with_wrong_crc(
+            &FantomeInfo {
+                name: "Mod".to_owned(),
+                ..Default::default()
+            },
+            payload,
+        );
+
+        let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+        let harvested = Hashtable::from_names(["ASSETS/Custom/New.tex"]).unwrap();
+        let mut sink = Cursor::new(Vec::new());
+        let outcome =
+            add_hashtables(&mut reader, &mut sink, &[(Category::Game, harvested)]).unwrap();
+        assert_eq!(outcome, RewriteOutcome::Rewritten { names_added: 1 });
+
+        let out = sink.into_inner();
+
+        // The wrong CRC32 was carried through, not recomputed.
+        let mut archive = zip::ZipArchive::new(Cursor::new(out.clone())).unwrap();
+        let entry = archive.by_name("WAD/Aatrox.wad.client/data/x.bin").unwrap();
+        assert_eq!(entry.crc32(), 0xDEAD_BEEF);
+        drop(entry);
+
+        // The content survived: extraction (which bypasses CRC) yields the
+        // original bytes.
+        let mut out_reader = FantomeReader::new(Cursor::new(out.clone())).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = camino::Utf8Path::from_path(dir.path()).unwrap();
+        out_reader
+            .extract_wads(dir_path, WadExtractOptions::new())
+            .unwrap();
+        let extracted =
+            std::fs::read(dir_path.join("Aatrox.wad.client/data/x.bin").as_std_path()).unwrap();
+        assert_eq!(extracted, payload);
+
+        // The manifest declares the table and the table reads back.
+        let info = out_reader.read_info().unwrap();
+        assert_eq!(info.hashtables.len(), 1);
+        assert_eq!(info.hashtables[0].path, "META/hashes/game.hashes.txt");
+        let tables = out_reader.read_hashtables().unwrap();
+        assert_eq!(
+            tables[0].1.names().collect::<Vec<_>>(),
+            ["ASSETS/Custom/New.tex"]
+        );
+    }
+}
+
+mod rewrite_merge {
+    use std::io::Cursor;
+
+    use ltk_hashtable::{Algorithm, Category, Hashtable};
+
+    use crate::{
+        FantomeHashtable, FantomeInfo, FantomeReader, FantomeWriter, RewriteOutcome, add_hashtables,
+    };
+
+    fn game_manifest() -> FantomeHashtable {
+        FantomeHashtable {
+            path: "META/hashes/game.hashes.txt".to_owned(),
+            category: Category::Game,
+            algorithm: Algorithm::Xxh64,
+            bits: 64,
+        }
+    }
+
+    fn archive_declaring(names: &[u8]) -> Vec<u8> {
+        let manifest = game_manifest();
+        let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));
+        writer
+            .write_info(&FantomeInfo {
+                name: "Mod".to_owned(),
+                hashtables: vec![manifest.clone()],
+                ..Default::default()
+            })
+            .unwrap();
+        writer
+            .write_hashtable(&manifest, &Hashtable::from_reader(names).unwrap())
+            .unwrap();
+        writer.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn a_harvest_that_adds_nothing_performs_no_rewrite() {
+        let bytes = archive_declaring(
+            b"ASSETS/Custom/Known.tex
+",
+        );
+        let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+
+        // The same canonical name in another casing is not new.
+        let harvested = Hashtable::from_names(["assets/custom/known.tex"]).unwrap();
+        let mut sink = Cursor::new(Vec::new());
+        let outcome =
+            add_hashtables(&mut reader, &mut sink, &[(Category::Game, harvested)]).unwrap();
+
+        assert_eq!(outcome, RewriteOutcome::Unchanged);
+        assert!(sink.into_inner().is_empty());
+    }
+
+    #[test]
+    fn a_merge_adds_to_an_existing_table_and_never_replaces_it() {
+        let bytes = archive_declaring(
+            b"b/Existing.tex
+",
+        );
+        let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+
+        let harvested =
+            Hashtable::from_names(["B/EXISTING.TEX", "a/new.tex", "A/NEW.TEX"]).unwrap();
+        let mut sink = Cursor::new(Vec::new());
+        let outcome =
+            add_hashtables(&mut reader, &mut sink, &[(Category::Game, harvested)]).unwrap();
+        assert_eq!(outcome, RewriteOutcome::Rewritten { names_added: 1 });
+
+        let mut out_reader = FantomeReader::new(Cursor::new(sink.into_inner())).unwrap();
+        let info = out_reader.read_info().unwrap();
+        assert_eq!(info.hashtables, vec![game_manifest()]);
+
+        let tables = out_reader.read_hashtables().unwrap();
+        assert_eq!(tables.len(), 1);
+        // The existing name survives in its authored casing; the new name
+        // lands beside it, sorted in byte order.
+        assert_eq!(
+            tables[0].1.names().collect::<Vec<_>>(),
+            ["a/new.tex", "b/Existing.tex"]
+        );
+    }
+}
+
+#[test]
+fn an_unknown_info_field_survives_a_rewrite() {
+    use std::io::{Cursor, Write as _};
+
+    use ltk_hashtable::{Category, Hashtable};
+    use zip::write::SimpleFileOptions;
+
+    // An info.json written by a newer or different tool, with a field this
+    // crate does not know.
+    let info_json = serde_json::json!({
+        "Name": "Mod",
+        "Author": "A",
+        "Version": "1.0.0",
+        "Description": "",
+        "SomeNewerField": {"nested": true}
+    });
+    let mut zip = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    zip.start_file("META/info.json", SimpleFileOptions::default())
+        .unwrap();
+    zip.write_all(info_json.to_string().as_bytes()).unwrap();
+    let bytes = zip.finish().unwrap().into_inner();
+
+    let mut reader = crate::FantomeReader::new(Cursor::new(bytes)).unwrap();
+    let harvested = Hashtable::from_names(["assets/custom/one.tex"]).unwrap();
+    let mut sink = Cursor::new(Vec::new());
+    crate::add_hashtables(&mut reader, &mut sink, &[(Category::Game, harvested)]).unwrap();
+
+    let mut out_reader = crate::FantomeReader::new(Cursor::new(sink.into_inner())).unwrap();
+    let info = out_reader.read_info().unwrap();
+    assert_eq!(
+        serde_json::to_value(&info).unwrap()["SomeNewerField"],
+        serde_json::json!({"nested": true})
+    );
+}
+
+#[test]
+fn a_packed_wad_reads_back_whole() {
+    use std::io::{Cursor, Write as _};
+
+    use ltk_wad::{WadBuilder, WadChunkBuilder};
+    use zip::write::SimpleFileOptions;
+
+    let mut wad_bytes = Cursor::new(Vec::new());
+    WadBuilder::default()
+        .with_chunk(WadChunkBuilder::default().with_path("data/x.bin"))
+        .build_to_writer(&mut wad_bytes, |_, cursor| {
+            cursor.write_all(b"chunk payload")?;
+            Ok(())
+        })
+        .unwrap();
+    let wad_bytes = wad_bytes.into_inner();
+
+    let mut zip = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    zip.start_file("WAD/Aatrox.wad.client", SimpleFileOptions::default())
+        .unwrap();
+    zip.write_all(&wad_bytes).unwrap();
+    let archive = zip.finish().unwrap().into_inner();
+
+    let mut reader = crate::FantomeReader::new(Cursor::new(archive)).unwrap();
+    assert_eq!(
+        reader.read_packed_wad("Aatrox.wad.client").unwrap(),
+        Some(wad_bytes)
+    );
+    assert_eq!(reader.read_packed_wad("Absent.wad.client").unwrap(), None);
+}
+
+#[test]
+fn a_manifest_entry_the_rewrite_cannot_read_is_never_shadowed() {
+    use std::io::{Cursor, Read as _};
+
+    use ltk_hashtable::{Category, Hashtable};
+
+    use crate::{FantomeReader, FantomeWriter, add_hashtables};
+
+    // A manifest entry whose Bits no key can have, sitting at the
+    // conventional path. This tool cannot read it - and must not touch it.
+    let unreadable = FantomeHashtable {
+        path: "META/hashes/game.hashes.txt".to_owned(),
+        category: ltk_hashtable::Category::Game,
+        algorithm: ltk_hashtable::Algorithm::Xxh64,
+        bits: 0,
+    };
+    let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));
+    writer
+        .write_info(&FantomeInfo {
+            name: "Mod".to_owned(),
+            hashtables: vec![unreadable.clone()],
+            ..Default::default()
+        })
+        .unwrap();
+    writer
+        .write_hashtable(
+            &unreadable,
+            &Hashtable::from_names(["some/opaque.name"]).unwrap(),
+        )
+        .unwrap();
+    let bytes = writer.finish().unwrap().into_inner();
+
+    let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+    let harvested = Hashtable::from_names(["assets/custom/new.tex"]).unwrap();
+    let mut sink = Cursor::new(Vec::new());
+    add_hashtables(&mut reader, &mut sink, &[(Category::Game, harvested)]).unwrap();
+
+    let out = sink.into_inner();
+    let mut out_reader = FantomeReader::new(Cursor::new(out.clone())).unwrap();
+    let info = out_reader.read_info().unwrap();
+
+    // Both entries are declared, at two distinct paths.
+    assert_eq!(info.hashtables.len(), 2);
+    assert_eq!(info.hashtables[0], unreadable);
+    assert_ne!(info.hashtables[1].path, unreadable.path);
+
+    // The unreadable entry survived byte-for-byte.
+    let mut archive = zip::ZipArchive::new(Cursor::new(out)).unwrap();
+    let mut file = archive.by_name("META/hashes/game.hashes.txt").unwrap();
+    let mut content = String::new();
+    file.read_to_string(&mut content).unwrap();
+    assert_eq!(
+        content,
+        "some/opaque.name
+"
+    );
+}
+
+#[test]
+fn a_sink_that_fails_part_way_surfaces_the_error() {
+    use std::io::{self, Cursor, Seek, SeekFrom, Write};
+
+    use ltk_hashtable::{Category, Hashtable};
+
+    use crate::{FantomeInfo, FantomeReader, FantomeWriter, add_hashtables};
+
+    /// A sink that refuses every write past a budget.
+    struct FailingSink {
+        inner: Cursor<Vec<u8>>,
+        budget: usize,
+    }
+
+    impl Write for FailingSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.budget < buf.len() {
+                return Err(io::Error::other("disk full"));
+            }
+            self.budget -= buf.len();
+            self.inner.write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.inner.flush()
+        }
+    }
+
+    impl Seek for FailingSink {
+        fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    let mut writer = FantomeWriter::new(Cursor::new(Vec::new()));
+    writer
+        .write_info(&FantomeInfo {
+            name: "Mod".to_owned(),
+            ..Default::default()
+        })
+        .unwrap();
+    writer
+        .write_wad_entry("Aatrox.wad.client", "assets/x.tex", &mut &b"payload"[..])
+        .unwrap();
+    let bytes = writer.finish().unwrap().into_inner();
+
+    let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+    let harvested = Hashtable::from_names(["assets/custom/new.tex"]).unwrap();
+    let sink = FailingSink {
+        inner: Cursor::new(Vec::new()),
+        budget: 64,
+    };
+
+    // The failure surfaces as an error rather than a truncated archive being
+    // reported written; keeping the original safe is the temp-and-rename
+    // above this call.
+    add_hashtables(&mut reader, sink, &[(Category::Game, harvested)]).unwrap_err();
 }

--- a/crates/ltk_fantome/src/writer.rs
+++ b/crates/ltk_fantome/src/writer.rs
@@ -10,7 +10,7 @@ use std::io::{Read, Seek, Write};
 use zip::ZipWriter;
 use zip::write::SimpleFileOptions;
 
-use crate::FantomeInfo;
+use crate::{FantomeHashtable, FantomeInfo};
 
 /// Failure to write a Fantome archive entry.
 #[derive(Debug, thiserror::Error)]
@@ -88,6 +88,31 @@ impl<W: Write + Seek> FantomeWriter<W> {
         content: &mut impl Read,
     ) -> Result<(), FantomeWriteError> {
         self.write_entry(&format!("META/{file_name}"), content)
+    }
+
+    /// The inner zip writer, for the rewrite's raw entry copies.
+    pub(crate) fn zip_mut(&mut self) -> &mut ZipWriter<W> {
+        &mut self.zip
+    }
+
+    /// Write one hashtable file at the path its manifest entry names.
+    ///
+    /// The manifest entry itself travels in `META/info.json`, via
+    /// [`write_info`](Self::write_info); this writes only the table file. A
+    /// table a manifest does not declare does not exist, so pass the same
+    /// entry to both.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry cannot be written.
+    pub fn write_hashtable(
+        &mut self,
+        manifest: &FantomeHashtable,
+        table: &ltk_hashtable::Hashtable,
+    ) -> Result<(), FantomeWriteError> {
+        self.zip.start_file(&manifest.path, self.options)?;
+        table.write_to(&mut self.zip)?;
+        Ok(())
     }
 
     /// Write the mod's thumbnail as `META/image.png`.

--- a/crates/ltk_hashtable/Cargo.toml
+++ b/crates/ltk_hashtable/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "ltk_fantome"
-version = "0.9.0"
+name = "ltk_hashtable"
+version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-description = "Helper library for working with League of Legends mods in the legacy Fantome format"
+description = "Embedded hashtable primitives for League of Legends mod containers"
 repository = "https://github.com/LeagueToolkit/league-mod"
 homepage = "https://github.com/LeagueToolkit/league-mod"
 documentation = "https://github.com/LeagueToolkit/league-mod/wiki"
@@ -13,14 +13,15 @@ categories = ["game-development"]
 authors = ["LeagueToolkit"]
 
 [dependencies]
-indexmap = { workspace = true }
-zip = "2.4"
+camino = { workspace = true }
+ltk_hash = { workspace = true }
+ltk_wad = { workspace = true, optional = true }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 thiserror = "2.0"
-camino = "1.1"
-ltk_wad = { workspace = true }
-ltk_hashtable = { version = "0.1.0", path = "../ltk_hashtable" }
+
+[features]
+# The bridge from a merged `game` category to `ltk_wad`'s `PathResolver`.
+wad = ["dep:ltk_wad"]
 
 [dev-dependencies]
-tempfile = "3.15"
+serde_json = "1.0"

--- a/crates/ltk_hashtable/src/entry.rs
+++ b/crates/ltk_hashtable/src/entry.rs
@@ -1,0 +1,55 @@
+//! [`HashtableEntry`]: the manifest entry as a domain type.
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::{Algorithm, Category, KeyWidth};
+
+/// One manifest entry: where a table file lives and how its names are keyed.
+///
+/// Carries no serde on purpose - each container spells the same four fields
+/// its own way and converts, the way the container manifests already convert
+/// between each other.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HashtableEntry {
+    path: Utf8PathBuf,
+    category: Category,
+    algorithm: Algorithm,
+    width: KeyWidth,
+}
+
+impl HashtableEntry {
+    /// Declare a table at `path`, relative to the container root.
+    pub fn new(
+        path: impl Into<Utf8PathBuf>,
+        category: Category,
+        algorithm: Algorithm,
+        width: KeyWidth,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            category,
+            algorithm,
+            width,
+        }
+    }
+
+    /// Where the table file lives, relative to the container root.
+    pub fn path(&self) -> &Utf8Path {
+        &self.path
+    }
+
+    /// The lookup domain of the table's names.
+    pub fn category(&self) -> &Category {
+        &self.category
+    }
+
+    /// The hash function keying the table's names.
+    pub fn algorithm(&self) -> &Algorithm {
+        &self.algorithm
+    }
+
+    /// The declared key width.
+    pub fn width(&self) -> KeyWidth {
+        self.width
+    }
+}

--- a/crates/ltk_hashtable/src/key.rs
+++ b/crates/ltk_hashtable/src/key.rs
@@ -1,0 +1,136 @@
+//! [`Key`]: a name's truncated hash, the unit every comparison runs on.
+
+use std::fmt;
+
+use ltk_hash::Hash as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A hashing algorithm the registry knows.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Algorithm {
+    /// 64-bit xxHash, seed 0 - the `game` hash space.
+    Xxh64,
+    /// 32-bit FNV-1a - the `binentries` and `binhashes` hash spaces.
+    Fnv1a32,
+    /// An algorithm this tool does not recognize, spelling kept verbatim.
+    ///
+    /// Its keys cannot be computed, so a table declaring one is skipped for
+    /// lookup - and preserved untouched on a rewrite or repack.
+    Unknown(String),
+}
+
+impl Algorithm {
+    /// The wire spelling.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Xxh64 => "xxh64",
+            Self::Fnv1a32 => "fnv1a_32",
+            Self::Unknown(spelling) => spelling,
+        }
+    }
+
+    /// Parse a wire spelling; anything unrecognized is [`Algorithm::Unknown`].
+    pub fn from_wire(spelling: &str) -> Self {
+        match spelling {
+            "xxh64" => Self::Xxh64,
+            "fnv1a_32" => Self::Fnv1a32,
+            other => Self::Unknown(other.to_owned()),
+        }
+    }
+}
+
+impl fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for Algorithm {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Algorithm {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::from_wire(&String::deserialize(deserializer)?))
+    }
+}
+
+/// A validated key width, in bits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KeyWidth(u8);
+
+impl KeyWidth {
+    /// Validate a declared bit count; `1..=64` is representable.
+    pub fn new(bits: u8) -> Option<Self> {
+        (1..=64).contains(&bits).then_some(Self(bits))
+    }
+
+    /// The width in bits.
+    pub fn bits(self) -> u8 {
+        self.0
+    }
+
+    /// The mask keeping a hash's low `bits`: `(1 << bits) - 1`.
+    fn mask(self) -> u64 {
+        u64::MAX >> (64 - u32::from(self.0))
+    }
+}
+
+/// A name's hash truncated to a declared width.
+///
+/// The only way to make one is [`Key::of`], which canonicalizes, hashes and
+/// truncates in one motion - a full hash never reaches a caller. `Display`
+/// renders fixed-width lowercase hex.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Key {
+    value: u64,
+    width: KeyWidth,
+}
+
+impl Key {
+    /// Canonicalize `name`, hash it with `algorithm` and truncate to `width`.
+    ///
+    /// Returns `None` when the algorithm cannot be computed.
+    pub fn of(name: &str, algorithm: &Algorithm, width: KeyWidth) -> Option<Self> {
+        let canonical = name.to_ascii_lowercase();
+        let hash = match algorithm {
+            Algorithm::Xxh64 => ltk_hash::WadHash::hash_str(&canonical).0,
+            Algorithm::Fnv1a32 => u64::from(ltk_hash::BinHash::hash_str(&canonical).0),
+            Algorithm::Unknown(_) => return None,
+        };
+        Some(Self {
+            value: hash & width.mask(),
+            width,
+        })
+    }
+
+    /// The key a hash value another crate holds truncates to.
+    ///
+    /// The inverse direction of [`Key::of`]: a caller holding a hash rather
+    /// than a name - a WAD chunk's path hash, say - truncates it here to look
+    /// it up. `value` is masked to the width's low bits, so a full hash and
+    /// an already-truncated one produce the same key.
+    pub fn from_value(value: u64, width: KeyWidth) -> Self {
+        Self {
+            value: value & width.mask(),
+            width,
+        }
+    }
+
+    /// The truncated value, for interop with hash types other crates hold.
+    ///
+    /// At a 64-bit width this is the full hash; at any narrower width it is
+    /// the masked low bits, never the untruncated hash.
+    pub fn value(self) -> u64 {
+        self.value
+    }
+}
+
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let digits = usize::from(self.width.bits().div_ceil(4));
+        write!(f, "{:0digits$x}", self.value)
+    }
+}

--- a/crates/ltk_hashtable/src/lib.rs
+++ b/crates/ltk_hashtable/src/lib.rs
@@ -1,0 +1,25 @@
+//! Primitives for the embedded hashtables a mod carries inside itself.
+//!
+//! This crate owns the table file grammar, name canonicalization, keys and
+//! their truncation, per-category merging, and collision detection. It has no
+//! notion of a container: where a table file lives, how it is compressed and
+//! how a manifest is spelled belong to the container crates.
+
+mod entry;
+mod key;
+mod registry;
+mod set;
+mod table;
+#[cfg(feature = "wad")]
+mod wad;
+
+pub use entry::HashtableEntry;
+pub use key::{Algorithm, Key, KeyWidth};
+pub use registry::Category;
+pub use set::{Collision, HashtableSet};
+pub use table::{Hashtable, HashtableReadError, InvalidNameError};
+#[cfg(feature = "wad")]
+pub use wad::GameResolver;
+
+#[cfg(test)]
+mod tests;

--- a/crates/ltk_hashtable/src/registry.rs
+++ b/crates/ltk_hashtable/src/registry.rs
@@ -1,0 +1,84 @@
+//! [`Category`]: the standard's open category registry.
+//!
+//! Both registries are open: a spelling a tool does not recognize is carried
+//! as `Unknown` verbatim, never dropped. The wire form of each is a bare
+//! lowercase string in every container, so the serde impls live on the domain
+//! types rather than in the containers - [`Category`]'s here, and
+//! [`Algorithm`]'s beside [`Key`](crate::Key) in the key module, where the
+//! hashing it names lives.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{Algorithm, KeyWidth};
+
+/// The lookup domain a table's names belong to.
+///
+/// An unknown category means the entry is ignored for lookup, and preserved
+/// untouched on a rewrite or repack.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Category {
+    /// WAD chunk paths and `File` property values, in the xxh64 hash space.
+    Game,
+    /// BIN object path names (entries).
+    BinEntries,
+    /// FNV-1a string hashes appearing as `Hash`-typed values.
+    BinHashes,
+    /// A category this tool does not recognize, spelling kept verbatim.
+    Unknown(String),
+}
+
+impl Category {
+    /// The wire spelling.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Game => "game",
+            Self::BinEntries => "binentries",
+            Self::BinHashes => "binhashes",
+            Self::Unknown(spelling) => spelling,
+        }
+    }
+
+    /// The algorithm and width the standard's registry currently lists for
+    /// this category, for declaring a new manifest entry.
+    ///
+    /// `None` for an unknown category. An existing manifest entry always
+    /// declares its own shape - this never overrides one.
+    pub fn default_shape(&self) -> Option<(Algorithm, KeyWidth)> {
+        let (algorithm, bits) = match self {
+            Self::Game => (Algorithm::Xxh64, 64),
+            Self::BinEntries | Self::BinHashes => (Algorithm::Fnv1a32, 32),
+            Self::Unknown(_) => return None,
+        };
+        Some((algorithm, KeyWidth::new(bits)?))
+    }
+
+    /// Parse a wire spelling; anything unrecognized is [`Category::Unknown`].
+    pub fn from_wire(spelling: &str) -> Self {
+        match spelling {
+            "game" => Self::Game,
+            "binentries" => Self::BinEntries,
+            "binhashes" => Self::BinHashes,
+            other => Self::Unknown(other.to_owned()),
+        }
+    }
+}
+
+impl fmt::Display for Category {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for Category {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Category {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::from_wire(&String::deserialize(deserializer)?))
+    }
+}

--- a/crates/ltk_hashtable/src/set.rs
+++ b/crates/ltk_hashtable/src/set.rs
@@ -1,0 +1,117 @@
+//! [`HashtableSet`]: the merged, per-category lookup.
+
+use std::collections::HashMap;
+
+use crate::{Category, Hashtable, HashtableEntry, Key, KeyWidth};
+
+/// Two different canonical names sharing one key - a packing error.
+///
+/// A duplicate (the same canonical name twice) is not a collision; readers
+/// keep its first occurrence silently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Collision {
+    /// The category both names were merged into.
+    pub category: Category,
+    /// The key both names truncate to.
+    pub key: Key,
+    /// The name that was kept.
+    pub first: String,
+    /// The name that became unresolvable.
+    pub second: String,
+}
+
+/// Every declared table merged into one lookup per category.
+///
+/// Merging is the standard's: tables in manifest order, lines in file order,
+/// first occurrence of a key wins. An entry whose category or algorithm is
+/// unknown is skipped for lookup (its keys cannot mean anything here) but is
+/// never anyone's to drop - preserving it is the container's job.
+#[derive(Debug, Clone, Default)]
+pub struct HashtableSet {
+    names: HashMap<Category, HashMap<Key, String>>,
+    /// The key widths each category's resolvable tables declared, widest
+    /// first, so a raw hash value can be truncated the ways a lookup needs.
+    widths: HashMap<Category, Vec<KeyWidth>>,
+    collisions: Vec<Collision>,
+}
+
+impl HashtableSet {
+    /// Merge `tables` in manifest order.
+    pub fn build(tables: impl IntoIterator<Item = (HashtableEntry, Hashtable)>) -> Self {
+        let mut names: HashMap<Category, HashMap<Key, String>> = HashMap::new();
+        let mut widths: HashMap<Category, Vec<KeyWidth>> = HashMap::new();
+        let mut collisions = Vec::new();
+        for (entry, table) in tables {
+            let merged = names.entry(entry.category().clone()).or_default();
+            let mut keyed_any = false;
+            for name in table.names() {
+                let Some(key) = Key::of(name, entry.algorithm(), entry.width()) else {
+                    continue;
+                };
+                keyed_any = true;
+                match merged.get(&key) {
+                    None => {
+                        merged.insert(key, name.to_owned());
+                    }
+                    Some(kept) if !kept.eq_ignore_ascii_case(name) => {
+                        // The same pair recurring is one collision, not many.
+                        let seen = collisions.iter().any(|collision: &Collision| {
+                            collision.key == key
+                                && collision.category == *entry.category()
+                                && collision.second.eq_ignore_ascii_case(name)
+                        });
+                        if !seen {
+                            collisions.push(Collision {
+                                category: entry.category().clone(),
+                                key,
+                                first: kept.clone(),
+                                second: name.to_owned(),
+                            });
+                        }
+                    }
+                    Some(_) => {}
+                }
+            }
+            if keyed_any {
+                let seen = widths.entry(entry.category().clone()).or_default();
+                if !seen.contains(&entry.width()) {
+                    seen.push(entry.width());
+                }
+            }
+        }
+        for seen in widths.values_mut() {
+            seen.sort_unstable_by_key(|width| std::cmp::Reverse(width.bits()));
+        }
+        Self {
+            names,
+            widths,
+            collisions,
+        }
+    }
+
+    /// The collisions merging ran into, in merge order.
+    ///
+    /// A pack must fail on any; a reader resolves what it can and should warn.
+    pub fn collisions(&self) -> &[Collision] {
+        &self.collisions
+    }
+
+    /// The name behind `key` in `category`, if any table holds one.
+    pub fn resolve(&self, category: &Category, key: Key) -> Option<&str> {
+        self.names.get(category)?.get(&key).map(String::as_str)
+    }
+
+    /// The name behind a raw hash value in `category`, if any table holds one.
+    ///
+    /// For a caller holding a hash another crate computed - a WAD chunk's
+    /// path hash, say - rather than a [`Key`]. The value is truncated to each
+    /// key width the category's tables declared, widest first, and the first
+    /// name found is the answer; a category whose tables all declare one
+    /// width (the common case) pays for one lookup.
+    pub fn resolve_value(&self, category: &Category, value: u64) -> Option<&str> {
+        self.widths
+            .get(category)?
+            .iter()
+            .find_map(|&width| self.resolve(category, Key::from_value(value, width)))
+    }
+}

--- a/crates/ltk_hashtable/src/table.rs
+++ b/crates/ltk_hashtable/src/table.rs
@@ -1,0 +1,150 @@
+//! [`Hashtable`]: one table's names, in file order.
+
+use std::io::{self, BufRead, BufReader, Read, Write};
+
+/// A name that does not fit the table grammar: printable ASCII, `/`
+/// separators.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("Not a valid name: {name:?}")]
+pub struct InvalidNameError {
+    name: String,
+}
+
+impl InvalidNameError {
+    /// The offending name, verbatim.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// Failure to read a hashtable file.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum HashtableReadError {
+    /// The table file could not be read.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+
+    /// The file starts with a byte order mark, which the grammar refuses.
+    #[error("The table file starts with a byte order mark")]
+    ByteOrderMark,
+
+    /// A line holds a character outside the grammar.
+    #[error("Line {line} is not a valid name")]
+    InvalidName {
+        /// The 1-based line number of the offending name.
+        line: usize,
+        /// The name that was refused.
+        #[source]
+        source: InvalidNameError,
+    },
+}
+
+/// Whether `name` fits the grammar: printable ASCII, `/` separators only.
+fn is_valid_name(name: &str) -> bool {
+    name.bytes()
+        .all(|byte| (0x20..=0x7e).contains(&byte) && byte != b'\\')
+}
+
+/// One hashtable file's names, in file order.
+///
+/// Holds names exactly as authored - display casing included. Canonicalizing
+/// and hashing happen at key computation, never here.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Hashtable {
+    names: Vec<String>,
+}
+
+impl Hashtable {
+    /// Read a table file: one name per line, blank lines skipped, CRLF
+    /// tolerated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if reading fails, the file starts with a BOM, or a
+    /// line holds a character outside the grammar.
+    pub fn from_reader(reader: impl Read) -> Result<Self, HashtableReadError> {
+        let mut names = Vec::new();
+        for (index, line) in BufReader::new(reader).lines().enumerate() {
+            let line = line?;
+            if index == 0 && line.starts_with('\u{feff}') {
+                return Err(HashtableReadError::ByteOrderMark);
+            }
+            if line.is_empty() {
+                continue;
+            }
+            if let Err(source) = Self::validated(&line) {
+                return Err(HashtableReadError::InvalidName {
+                    line: index + 1,
+                    source,
+                });
+            }
+            names.push(line);
+        }
+        Ok(Self { names })
+    }
+
+    /// Build a table from `names`, in iteration order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a name does not fit the grammar: printable ASCII
+    /// with `/` separators.
+    pub fn from_names(
+        names: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Result<Self, InvalidNameError> {
+        let mut table = Self::default();
+        for name in names {
+            table.push(name)?;
+        }
+        Ok(table)
+    }
+
+    /// Check `name` against the grammar.
+    fn validated(name: &str) -> Result<(), InvalidNameError> {
+        if is_valid_name(name) {
+            Ok(())
+        } else {
+            Err(InvalidNameError {
+                name: name.to_owned(),
+            })
+        }
+    }
+
+    /// Append one name, in table order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the name does not fit the grammar: printable ASCII
+    /// with `/` separators.
+    pub fn push(&mut self, name: impl Into<String>) -> Result<(), InvalidNameError> {
+        let name = name.into();
+        Self::validated(&name)?;
+        self.names.push(name);
+        Ok(())
+    }
+
+    /// Sort the names in `LC_ALL=C` byte order, the order version control
+    /// diffs best.
+    pub fn sort(&mut self) {
+        self.names.sort_unstable();
+    }
+
+    /// The table's names, in table order.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.names.iter().map(String::as_str)
+    }
+
+    /// Write the table: one name per line, LF-terminated, in table order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing fails.
+    pub fn write_to(&self, mut writer: impl Write) -> io::Result<()> {
+        for name in &self.names {
+            writer.write_all(name.as_bytes())?;
+            writer.write_all(b"\n")?;
+        }
+        Ok(())
+    }
+}

--- a/crates/ltk_hashtable/src/tests.rs
+++ b/crates/ltk_hashtable/src/tests.rs
@@ -1,0 +1,337 @@
+use crate::Hashtable;
+
+// Grammar: the table file is name-only, LF, forward-slash lines. A table
+// round trips its names, their display casing and their order.
+
+#[test]
+fn table_file_round_trips_names_casing_and_order() {
+    let src = "ASSETS/Characters/Aurora/Skins/Skin0/Aurora_Custom.TEX\n\
+               assets/maps/kit/zzz.dds\n\
+               DATA/Characters/Aurora/aurora.bin\n";
+
+    let table = Hashtable::from_reader(src.as_bytes()).unwrap();
+    let mut out = Vec::new();
+    table.write_to(&mut out).unwrap();
+
+    assert_eq!(String::from_utf8(out).unwrap(), src);
+}
+
+#[test]
+fn crlf_and_blank_lines_read_as_the_same_names() {
+    let unix = "a/b.dds\nc/d.bin\n";
+    let windows = "a/b.dds\r\n\r\nc/d.bin\r\n\n";
+
+    let from_unix = Hashtable::from_reader(unix.as_bytes()).unwrap();
+    let from_windows = Hashtable::from_reader(windows.as_bytes()).unwrap();
+
+    assert_eq!(from_unix, from_windows);
+}
+
+#[test]
+fn a_bom_is_refused() {
+    let src = b"\xEF\xBB\xBFa/b.dds\n";
+    Hashtable::from_reader(&src[..]).unwrap_err();
+}
+
+#[test]
+fn a_backslash_and_a_non_printable_byte_are_refused() {
+    Hashtable::from_reader(&b"a\\b.dds\n"[..]).unwrap_err();
+    Hashtable::from_reader(&b"a/\x07b.dds\n"[..]).unwrap_err();
+    Hashtable::from_reader("a/\u{00e9}.dds\n".as_bytes()).unwrap_err();
+}
+
+// Keys: canonicalize, hash, truncate and render in one motion.
+
+use crate::{Algorithm, Key, KeyWidth};
+
+#[test]
+fn xxh64_matches_the_known_vector() {
+    // xxh64("abc", seed 0) - reference vector from the xxHash test suite.
+    let width = KeyWidth::new(64).unwrap();
+    let key = Key::of("abc", &Algorithm::Xxh64, width).unwrap();
+    assert_eq!(key.to_string(), "44bc2cf5ad770999");
+}
+
+#[test]
+fn fnv1a32_matches_the_known_vector() {
+    // fnv1a_32("abc") - reference vector from the FNV test suite.
+    let width = KeyWidth::new(32).unwrap();
+    let key = Key::of("abc", &Algorithm::Fnv1a32, width).unwrap();
+    assert_eq!(key.to_string(), "1a47e90b");
+}
+
+#[test]
+fn two_spellings_of_one_name_share_one_key() {
+    let width = KeyWidth::new(64).unwrap();
+    let upper = Key::of("ASSETS/Foo/Bar.TEX", &Algorithm::Xxh64, width).unwrap();
+    let lower = Key::of("assets/foo/bar.tex", &Algorithm::Xxh64, width).unwrap();
+    assert_eq!(upper, lower);
+}
+
+#[test]
+fn a_key_is_the_hash_truncated_to_the_declared_width() {
+    // xxh64("abc") = 0x44bc2cf5ad770999; the low 16 bits are 0x0999.
+    let width = KeyWidth::new(16).unwrap();
+    let key = Key::of("abc", &Algorithm::Xxh64, width).unwrap();
+    assert_eq!(key.to_string(), "0999");
+}
+
+#[test]
+fn hex_zero_pads_a_width_that_is_not_a_multiple_of_four() {
+    // The low 10 bits of 0x...0999 are 0x199, rendered at ceil(10/4) digits.
+    let width = KeyWidth::new(10).unwrap();
+    let key = Key::of("abc", &Algorithm::Xxh64, width).unwrap();
+    assert_eq!(key.to_string(), "199");
+}
+
+// Registry: Category and Algorithm are open registries whose wire form is a
+// bare lowercase string, shared by all three containers.
+
+use crate::Category;
+
+#[test]
+fn categories_and_algorithms_round_trip_their_wire_spelling() {
+    for (value, wire) in [
+        (Category::Game, "\"game\""),
+        (Category::BinEntries, "\"binentries\""),
+        (Category::BinHashes, "\"binhashes\""),
+        (
+            Category::Unknown("stringtable".to_owned()),
+            "\"stringtable\"",
+        ),
+    ] {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(serde_json::from_str::<Category>(wire).unwrap(), value);
+    }
+
+    for (value, wire) in [
+        (Algorithm::Xxh64, "\"xxh64\""),
+        (Algorithm::Fnv1a32, "\"fnv1a_32\""),
+        (Algorithm::Unknown("xxh3".to_owned()), "\"xxh3\""),
+    ] {
+        assert_eq!(serde_json::to_string(&value).unwrap(), wire);
+        assert_eq!(serde_json::from_str::<Algorithm>(wire).unwrap(), value);
+    }
+}
+
+#[test]
+fn an_unknown_algorithm_computes_no_key() {
+    let width = KeyWidth::new(64).unwrap();
+    let algorithm = Algorithm::Unknown("xxh3".to_owned());
+    assert_eq!(Key::of("abc", &algorithm, width), None);
+}
+
+// Merging: tables in manifest order, lines in file order, first key wins.
+
+use crate::{HashtableEntry, HashtableSet};
+
+fn game_entry(path: &str) -> HashtableEntry {
+    HashtableEntry::new(
+        path,
+        Category::Game,
+        Algorithm::Xxh64,
+        KeyWidth::new(64).unwrap(),
+    )
+}
+
+fn game_key(name: &str) -> Key {
+    Key::of(name, &Algorithm::Xxh64, KeyWidth::new(64).unwrap()).unwrap()
+}
+
+#[test]
+fn merging_keeps_the_first_key_in_manifest_then_file_order() {
+    let first = Hashtable::from_reader(&b"ASSETS/One.tex\n"[..]).unwrap();
+    let second = Hashtable::from_reader(&b"assets/one.tex\nassets/two.tex\n"[..]).unwrap();
+
+    let set = HashtableSet::build([
+        (game_entry("META/hashes/game.hashes.txt"), first),
+        (game_entry("META/hashes/game.imported.hashes.txt"), second),
+    ]);
+
+    // The duplicate keeps the first occurrence - display casing included.
+    assert_eq!(
+        set.resolve(&Category::Game, game_key("assets/one.tex")),
+        Some("ASSETS/One.tex")
+    );
+    assert_eq!(
+        set.resolve(&Category::Game, game_key("assets/two.tex")),
+        Some("assets/two.tex")
+    );
+    assert_eq!(
+        set.resolve(&Category::Game, game_key("assets/absent.tex")),
+        None
+    );
+}
+
+#[test]
+fn a_collision_is_detected_across_two_files_of_one_category() {
+    // fnv1a_32("data/strings/name_1") = 0x38b3564a and
+    // fnv1a_32("data/strings/name_50") = 0xc446a14a collide on the low 8 bits.
+    let width = KeyWidth::new(8).unwrap();
+    let entry =
+        |path: &str| HashtableEntry::new(path, Category::BinHashes, Algorithm::Fnv1a32, width);
+    let first = Hashtable::from_reader(&b"data/strings/name_1\n"[..]).unwrap();
+    let second = Hashtable::from_reader(&b"data/strings/name_50\n"[..]).unwrap();
+
+    let set = HashtableSet::build([
+        (entry("hashes/binhashes.hashes.txt"), first),
+        (entry("hashes/binhashes.imported.hashes.txt"), second),
+    ]);
+
+    let collisions = set.collisions();
+    assert_eq!(collisions.len(), 1);
+    assert_eq!(collisions[0].category, Category::BinHashes);
+    assert_eq!(collisions[0].first, "data/strings/name_1");
+    assert_eq!(collisions[0].second, "data/strings/name_50");
+    assert_eq!(collisions[0].key.to_string(), "4a");
+
+    // A reader that runs into one anyway keeps the first occurrence.
+    let key = Key::of("data/strings/name_1", &Algorithm::Fnv1a32, width).unwrap();
+    assert_eq!(
+        set.resolve(&Category::BinHashes, key),
+        Some("data/strings/name_1")
+    );
+}
+
+#[test]
+fn a_duplicate_is_not_a_collision() {
+    let first = Hashtable::from_reader(&b"ASSETS/One.tex\nassets/one.tex\n"[..]).unwrap();
+    let set = HashtableSet::build([(game_entry("hashes/game.hashes.txt"), first)]);
+    assert!(set.collisions().is_empty());
+}
+
+#[test]
+fn a_table_with_an_unknown_algorithm_is_skipped_for_lookup() {
+    let entry = HashtableEntry::new(
+        "hashes/game.hashes.txt",
+        Category::Game,
+        Algorithm::Unknown("xxh3".to_owned()),
+        KeyWidth::new(64).unwrap(),
+    );
+    let table = Hashtable::from_reader(&b"assets/one.tex\n"[..]).unwrap();
+
+    let set = HashtableSet::build([(entry, table)]);
+
+    // The same name keyed by a known algorithm resolves to nothing: the
+    // unknown table contributed no keys.
+    assert_eq!(
+        set.resolve(&Category::Game, game_key("assets/one.tex")),
+        None
+    );
+    assert!(set.collisions().is_empty());
+}
+
+// Raw hash values: the interop direction, for hashes other crates hold.
+
+#[test]
+fn from_value_masks_to_the_width_and_matches_of() {
+    let width = KeyWidth::new(8).unwrap();
+    let key = Key::of("data/strings/name_1", &Algorithm::Fnv1a32, width).unwrap();
+
+    // The full 32-bit hash truncates to the same key.
+    assert_eq!(Key::from_value(0x38b3_564a, width), key);
+    // An already-truncated value is left as it is.
+    assert_eq!(Key::from_value(0x4a, width), key);
+}
+
+#[test]
+fn a_raw_hash_value_resolves_through_every_declared_width() {
+    let narrow = HashtableEntry::new(
+        "hashes/game.narrow.hashes.txt",
+        Category::Game,
+        Algorithm::Xxh64,
+        KeyWidth::new(32).unwrap(),
+    );
+    let set = HashtableSet::build([
+        (
+            game_entry("hashes/game.hashes.txt"),
+            Hashtable::from_reader(&b"assets/one.tex\n"[..]).unwrap(),
+        ),
+        (
+            narrow,
+            Hashtable::from_reader(&b"assets/two.tex\n"[..]).unwrap(),
+        ),
+    ]);
+
+    let full_hash = |name: &str| game_key(name).value();
+    assert_eq!(
+        set.resolve_value(&Category::Game, full_hash("assets/one.tex")),
+        Some("assets/one.tex")
+    );
+    // The name in the 32-bit table resolves from the full 64-bit hash: the
+    // value is truncated to each declared width until one answers.
+    assert_eq!(
+        set.resolve_value(&Category::Game, full_hash("assets/two.tex")),
+        Some("assets/two.tex")
+    );
+    assert_eq!(
+        set.resolve_value(&Category::Game, full_hash("assets/absent.tex")),
+        None
+    );
+}
+
+// Producer side: building and sorting tables.
+
+#[test]
+fn a_table_builds_from_names_and_refuses_an_invalid_one() {
+    let table = Hashtable::from_names(["b/B.tex", "a/a.tex"]).unwrap();
+    assert_eq!(table.names().collect::<Vec<_>>(), ["b/B.tex", "a/a.tex"]);
+
+    Hashtable::from_names(["ok.tex", "bad\u{7}.tex"]).unwrap_err();
+}
+
+#[test]
+fn sorting_is_byte_order_so_uppercase_sorts_before_lowercase() {
+    let mut table = Hashtable::from_names(["b/b.tex", "B/a.tex", "a/a.tex"]).unwrap();
+    table.sort();
+    assert_eq!(
+        table.names().collect::<Vec<_>>(),
+        ["B/a.tex", "a/a.tex", "b/b.tex"]
+    );
+}
+
+#[test]
+fn a_known_category_knows_its_standard_shape() {
+    let (algorithm, width) = Category::Game.default_shape().unwrap();
+    assert_eq!(algorithm, Algorithm::Xxh64);
+    assert_eq!(width.bits(), 64);
+
+    let (algorithm, width) = Category::BinHashes.default_shape().unwrap();
+    assert_eq!(algorithm, Algorithm::Fnv1a32);
+    assert_eq!(width.bits(), 32);
+
+    assert_eq!(
+        Category::BinEntries.default_shape().unwrap().0,
+        Algorithm::Fnv1a32
+    );
+    assert_eq!(
+        Category::Unknown("stringtable".to_owned()).default_shape(),
+        None
+    );
+}
+
+#[test]
+fn a_key_exposes_its_truncated_value() {
+    let width = KeyWidth::new(16).unwrap();
+    let key = Key::of("abc", &Algorithm::Xxh64, width).unwrap();
+    assert_eq!(key.value(), 0x0999);
+}
+
+#[test]
+fn a_colliding_pair_is_reported_once_however_often_it_recurs() {
+    let width = KeyWidth::new(8).unwrap();
+    let entry =
+        |path: &str| HashtableEntry::new(path, Category::BinHashes, Algorithm::Fnv1a32, width);
+    let first = Hashtable::from_reader(&b"data/strings/name_1\n"[..]).unwrap();
+    let second = Hashtable::from_reader(
+        &b"data/strings/name_50\nDATA/STRINGS/NAME_50\ndata/strings/name_50\n"[..],
+    )
+    .unwrap();
+
+    let set = HashtableSet::build([
+        (entry("hashes/a.hashes.txt"), first),
+        (entry("hashes/b.hashes.txt"), second),
+    ]);
+
+    assert_eq!(set.collisions().len(), 1);
+}

--- a/crates/ltk_hashtable/src/wad.rs
+++ b/crates/ltk_hashtable/src/wad.rs
@@ -1,0 +1,66 @@
+//! [`GameResolver`]: the merged `game` category as an `ltk_wad` resolver.
+//!
+//! Only compiled with the `wad` cargo feature, so callers that never touch a
+//! WAD pull no WAD machinery in.
+
+use ltk_wad::{PathResolver, WadHash};
+
+use crate::{Category, HashtableSet};
+
+/// Resolves WAD chunk hashes through a set's merged `game` category.
+///
+/// The bridge from embedded tables to [`ltk_wad`]: an extraction that should
+/// name chunks from a mod's own tables wraps the set here and passes the
+/// result wherever a [`PathResolver`] is asked for. `game` names are paths
+/// relative to the WAD root in the xxh64 hash space, which is exactly what a
+/// [`WadHash`] keys, so the categories line up by construction.
+///
+/// # Example
+///
+/// ```
+/// use ltk_hashtable::{
+///     Algorithm, Category, GameResolver, Hashtable, HashtableEntry, HashtableSet, KeyWidth,
+/// };
+/// use ltk_wad::PathResolver;
+///
+/// let entry = HashtableEntry::new(
+///     "hashes/game.hashes.txt",
+///     Category::Game,
+///     Algorithm::Xxh64,
+///     KeyWidth::new(64).unwrap(),
+/// );
+/// let table = Hashtable::from_names(["assets/custom/trail.tex"]).unwrap();
+/// let set = HashtableSet::build([(entry, table)]);
+///
+/// let resolver = GameResolver::new(&set);
+/// let hash = ltk_wad::WadHash::from("assets/custom/trail.tex");
+/// assert_eq!(resolver.resolve(hash).as_deref(), Some("assets/custom/trail.tex"));
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct GameResolver<'a> {
+    set: &'a HashtableSet,
+}
+
+impl<'a> GameResolver<'a> {
+    /// Resolve through the `game` category of `set`.
+    ///
+    /// The set's other categories are ignored: nothing in a WAD is keyed the
+    /// way `binentries` or `binhashes` names are.
+    pub fn new(set: &'a HashtableSet) -> Self {
+        Self { set }
+    }
+}
+
+impl PathResolver for GameResolver<'_> {
+    fn resolve(&self, path_hash: WadHash) -> Option<String> {
+        self.set
+            .resolve_value(&Category::Game, path_hash.0)
+            .map(str::to_owned)
+    }
+
+    fn is_known(&self, path_hash: WadHash) -> bool {
+        self.set
+            .resolve_value(&Category::Game, path_hash.0)
+            .is_some()
+    }
+}

--- a/crates/ltk_mod_project/Cargo.toml
+++ b/crates/ltk_mod_project/Cargo.toml
@@ -20,10 +20,13 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0"
 toml = "0.8.19"
 serde_json = "1.0"
+ltk_hashtable = { version = "0.1.0", path = "../ltk_hashtable" }
 
 # Optional: packing backends, one cargo feature per format
 ltk_modpkg = { version = "0.9.0", path = "../ltk_modpkg", optional = true }
 ltk_fantome = { version = "0.9.0", path = "../ltk_fantome", optional = true }
+ltk_wad = { workspace = true, optional = true }
+tempfile = { version = "3.15", optional = true }
 image = { version = "0.25", default-features = false, features = [
     "webp",
     "png",
@@ -40,7 +43,14 @@ slug = { version = "0.1", optional = true }
 [features]
 default = []
 modpkg = ["dep:ltk_modpkg", "dep:image", "dep:webp-animation", "dep:semver"]
-fantome = ["dep:ltk_fantome", "dep:image", "dep:slug"]
+fantome = [
+    "dep:ltk_fantome",
+    "dep:image",
+    "dep:slug",
+    "dep:ltk_wad",
+    "dep:tempfile",
+    "ltk_hashtable/wad",
+]
 
 [dev-dependencies]
 ltk_wad = { workspace = true }

--- a/crates/ltk_mod_project/src/fantome/convert.rs
+++ b/crates/ltk_mod_project/src/fantome/convert.rs
@@ -2,9 +2,17 @@
 
 use std::collections::HashMap;
 
-use ltk_fantome::{FantomeInfo, FantomeLayerInfo, FantomeLicense};
+use camino::Utf8Path;
 
-use crate::{ModMap, ModProject, ModProjectAuthor, ModProjectLayer, ModProjectLicense, ModTag};
+use crate::hashtable_routes::{
+    file_name_of, is_plain_tail, HashtableRoute, NameClaims, PlannedRoute,
+};
+use ltk_fantome::{FantomeHashtable, FantomeInfo, FantomeLayerInfo, FantomeLicense};
+
+use crate::{
+    ModMap, ModProject, ModProjectAuthor, ModProjectHashtable, ModProjectLayer, ModProjectLicense,
+    ModTag, HASHES_DIR_NAME,
+};
 
 impl From<&ModProjectLicense> for FantomeLicense {
     fn from(license: &ModProjectLicense) -> Self {
@@ -40,6 +48,12 @@ impl From<&ModProject> for FantomeInfo {
             champions: mod_project.champions.clone(),
             maps: mod_project.maps.iter().map(|m| m.to_string()).collect(),
             layers: build_fantome_layers(mod_project),
+            // The pack owns the hashtable manifest: it computes the routes
+            // once (fallibly - colliding file names are refused) and writes
+            // what they declare, so the entries and the manifest cannot
+            // disagree.
+            hashtables: vec![],
+            extra: Default::default(),
         }
     }
 }
@@ -63,8 +77,116 @@ impl From<FantomeInfo> for ModProject {
             transformers: vec![],
             layers: layers_from_fantome(info.layers),
             thumbnail: None,
+            // The import owns the hashtable manifest: it computes the routes
+            // once (fallibly - colliding file names are refused) and writes
+            // the files where they declare, so the files and the manifest
+            // cannot disagree.
+            hashtables: vec![],
         }
     }
+}
+
+/// Where each of an archive's `Hashtables` declarations lands in the
+/// project.
+///
+/// Each path is rewritten to where the importer writes the file: an archive
+/// path under `META/hashes/` keeps its tail beneath `hashes/`, and a table
+/// declared anywhere else lands under `hashes/` by its file name. Two
+/// entries declaring one archive file keep declaring one project file.
+///
+/// An entry whose declared width no key can have is dropped rather than
+/// carried: its table cannot be read out of the archive (see
+/// `FantomeReader::read_hashtables`), so keeping the declaration would
+/// declare a file the import never writes.
+///
+/// # Errors
+///
+/// [`DuplicateHashtableName`](crate::DuplicateHashtableName) when two
+/// different declared files land on one project file name - writing both
+/// would clobber one with the other, and an ambiguous archive must not be
+/// guessed at.
+pub(crate) fn project_routes(
+    declared: &[FantomeHashtable],
+) -> Result<Vec<HashtableRoute<ModProjectHashtable>>, crate::DuplicateHashtableName> {
+    let mut claims = NameClaims::default();
+    declared
+        .iter()
+        .filter(|manifest| manifest.to_entry().is_some())
+        .map(|manifest| {
+            let mapped = ModProjectHashtable {
+                path: claims.claim(
+                    HASHES_DIR_NAME,
+                    meta_hashes_tail(&manifest.path)
+                        .filter(|tail| is_plain_tail(tail))
+                        .unwrap_or_else(|| file_name_of(&manifest.path)),
+                    &manifest.path,
+                )?,
+                category: manifest.category.clone(),
+                algorithm: manifest.algorithm.clone(),
+                bits: manifest.bits,
+            };
+            Ok(HashtableRoute {
+                source: manifest.path.clone(),
+                manifest: mapped,
+            })
+        })
+        .collect()
+}
+
+/// Where each planned table lands in the archive, paired with its table.
+///
+/// The mirror of [`project_routes`]: every planned table maps, verbatim
+/// except for the path. A path under `hashes/` keeps its tail beneath
+/// `META/hashes/`, so pack, import, pack again keeps every table where it
+/// was; a table declared elsewhere in the project lands under `META/hashes/`
+/// by its file name.
+///
+/// # Errors
+///
+/// [`DuplicateHashtableName`](crate::DuplicateHashtableName) when two
+/// different declared files land on one archive name - refused rather than
+/// renamed, since the author can rename a file and a silently renamed table
+/// would ship under a name nobody chose.
+pub(crate) fn fantome_routes(
+    planned: &[crate::pack::PlannedHashtable],
+) -> Result<Vec<PlannedRoute<'_, FantomeHashtable>>, crate::DuplicateHashtableName> {
+    let mut claims = NameClaims::default();
+    planned
+        .iter()
+        .map(|planned| {
+            let source = planned.entry().path();
+            let mapped = FantomeHashtable {
+                path: claims.claim(
+                    "META/hashes",
+                    source
+                        .strip_prefix(HASHES_DIR_NAME)
+                        .ok()
+                        .map(Utf8Path::as_str)
+                        .filter(|tail| is_plain_tail(tail))
+                        .unwrap_or_else(|| file_name_of(source.as_str())),
+                    source.as_str(),
+                )?,
+                category: planned.entry().category().clone(),
+                algorithm: planned.entry().algorithm().clone(),
+                bits: planned.entry().width().bits(),
+            };
+            Ok(PlannedRoute {
+                manifest: mapped,
+                planned,
+            })
+        })
+        .collect()
+}
+
+/// The tail of an archive path under `META/hashes/`, in any casing, or `None`
+/// for a path declared elsewhere in the archive.
+fn meta_hashes_tail(archive_path: &str) -> Option<&str> {
+    const PREFIX: &str = "META/hashes/";
+    archive_path
+        .get(..PREFIX.len())
+        .filter(|prefix| prefix.eq_ignore_ascii_case(PREFIX))
+        .map(|_| &archive_path[PREFIX.len()..])
+        .filter(|tail| !tail.is_empty())
 }
 
 /// The layer table an archive's `META/info.json` declares.

--- a/crates/ltk_mod_project/src/fantome/import.rs
+++ b/crates/ltk_mod_project/src/fantome/import.rs
@@ -1,5 +1,6 @@
 //! [`FantomeImporter`]: decodes a Fantome archive into a mod project directory.
 
+use std::collections::HashMap;
 use std::fmt;
 use std::io::{Read, Seek};
 
@@ -8,6 +9,8 @@ use ltk_fantome::{
     classify_entry, FantomeEntry, FantomeExtractError, FantomeReader, NamingPolicy, NoResolver,
     PathResolver, WadExtractOptions, WadProgress,
 };
+use ltk_hashtable::{GameResolver, Hashtable, HashtableEntry, HashtableSet};
+use ltk_wad::WadHash;
 
 use crate::{ImportFormat, ImportReporter, ImportTarget, ModProject, ModProjectLayer};
 
@@ -36,6 +39,16 @@ pub enum FantomeImportError {
     #[error("Failed to convert the thumbnail")]
     Thumbnail(#[source] Box<dyn std::error::Error + Send + Sync>),
 
+    /// Two declared hashtable files land on one project file name.
+    ///
+    /// Declared tables land flat under `hashes/` by file name (a
+    /// `META/hashes/` tail is carried whole), so declarations from
+    /// different places can collide - and writing both would clobber one
+    /// with the other. An archive shaped like this is ambiguous, and an
+    /// import must not invent names to resolve it.
+    #[error(transparent)]
+    DuplicateHashtableName(#[from] crate::DuplicateHashtableName),
+
     /// The import's cancellation answered `true`. The driver folds this into
     /// [`ImportError::Cancelled`](crate::ImportError::Cancelled).
     #[error("The import was cancelled")]
@@ -61,6 +74,10 @@ impl FantomeImportError {
 /// 2. Extract `RAW/` entries to `content/base/raw/`, and `README.md`, the
 ///    license text and the thumbnail (converted to `thumbnail.webp`), if
 ///    present
+/// 3. Recover the hashtables the archive declares into `hashes/`, with the
+///    project manifest rewritten to the new paths - and name packed WAD
+///    chunks from those tables first, ahead of the supplied resolver, since
+///    the mod's own table is the authority on the names its author invented
 ///
 /// The project the archive's metadata describes is returned for the driver to
 /// write out as `mod.config.json`.
@@ -157,7 +174,24 @@ impl<R: Read + Seek> ImportFormat for FantomeImporter<'_, R> {
         } = self;
 
         let mut reader = FantomeReader::new(reader)?;
-        let mod_project = ModProject::from(reader.read_info()?);
+        let info = reader.read_info()?;
+        // Where each declared table lands. Computed once, before anything is
+        // written: what the routes declare is what the config carries and
+        // where the files land, so the files and the manifest cannot
+        // disagree - and an archive whose tables collide on one file name is
+        // refused before the import touches the output directory.
+        let routes = super::convert::project_routes(&info.hashtables)?;
+        let table_routes: HashMap<&str, &str> = routes
+            .iter()
+            .map(|route| (route.source.as_str(), route.manifest.path.as_str()))
+            .collect();
+        let mut mod_project = ModProject::from(info);
+        mod_project.hashtables = routes.iter().map(|route| route.manifest.clone()).collect();
+
+        // Read before the WADs are unpacked: the mod's own tables name its
+        // chunks, ahead of whatever resolver the caller supplied.
+        let declared_tables = reader.read_hashtables()?;
+        let own_names = HashtableSet::build(declared_tables.iter().cloned());
 
         let output_dir = target.output_dir();
         let cancellation = target.cancellation();
@@ -175,8 +209,12 @@ impl<R: Read + Seek> ImportFormat for FantomeImporter<'_, R> {
         {
             let mut on_wad = |wad: WadProgress<'_>| progress.report_item(wad.name);
 
+            let chained = ChainedResolver {
+                own: GameResolver::new(&own_names),
+                fallback: resolver.unwrap_or(&NoResolver),
+            };
             let options = WadExtractOptions::new()
-                .with_path_resolver(resolver.unwrap_or(&NoResolver))
+                .with_path_resolver(&chained)
                 .with_naming_policy(naming)
                 .with_progress(&mut on_wad)
                 .with_cancellation(&is_cancelled);
@@ -217,6 +255,8 @@ impl<R: Read + Seek> ImportFormat for FantomeImporter<'_, R> {
             write_thumbnail(&png, &output_dir.join("thumbnail.webp"))?;
         }
 
+        write_hashtables(output_dir, &table_routes, &declared_tables)?;
+
         Ok(mod_project)
     }
 
@@ -240,6 +280,57 @@ fn import_error(source: FantomeExtractError) -> FantomeImportError {
         FantomeExtractError::Cancelled => FantomeImportError::Cancelled,
         other => FantomeImportError::Extract(other),
     }
+}
+
+/// Names chunks from the mod's own declared tables first, the caller's
+/// resolver second.
+struct ChainedResolver<'a, 'b> {
+    own: GameResolver<'a>,
+    fallback: &'b dyn PathResolver,
+}
+
+impl PathResolver for ChainedResolver<'_, '_> {
+    fn resolve(&self, path_hash: WadHash) -> Option<String> {
+        self.own
+            .resolve(path_hash)
+            .or_else(|| self.fallback.resolve(path_hash))
+    }
+
+    fn is_known(&self, path_hash: WadHash) -> bool {
+        self.own.is_known(path_hash) || self.fallback.is_known(path_hash)
+    }
+}
+
+/// Write the archive's declared tables into `hashes/`, each at the project
+/// path its route names.
+///
+/// The routes and the config manifest come from one mapping over one input,
+/// and the pairing here is by the declared archive path rather than by list
+/// position, so neither side's filtering can mispair them.
+fn write_hashtables(
+    output_dir: &Utf8Path,
+    routes: &HashMap<&str, &str>,
+    tables: &[(HashtableEntry, Hashtable)],
+) -> Result<(), FantomeImportError> {
+    for (entry, table) in tables {
+        let project_path = routes
+            .get(entry.path().as_str())
+            .expect("every table read out of the manifest has a route from the same manifest");
+        let path = output_dir.join(project_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent.as_std_path())
+                .map_err(|source| FantomeImportError::write(parent, source))?;
+        }
+        let mut file = std::io::BufWriter::new(
+            std::fs::File::create(path.as_std_path())
+                .map_err(|source| FantomeImportError::write(&path, source))?,
+        );
+        table
+            .write_to(&mut file)
+            .and_then(|()| std::io::Write::flush(&mut file))
+            .map_err(|source| FantomeImportError::write(&path, source))?;
+    }
+    Ok(())
 }
 
 fn write_file(path: &Utf8Path, bytes: &[u8]) -> Result<(), FantomeImportError> {

--- a/crates/ltk_mod_project/src/fantome/layout.rs
+++ b/crates/ltk_mod_project/src/fantome/layout.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Seek};
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_fantome::{classify_entry, FantomeEntry, FantomeReader};
 
-use crate::{ModProjectLayer, ProjectPath, ProjectPaths};
+use crate::{ModProjectLayer, ProjectPath, ProjectPaths, HASHES_DIR_NAME};
 
 /// A Fantome archive answers where an import would put every entry it holds.
 ///
@@ -64,6 +64,7 @@ pub(crate) fn project_path(entry_name: &str) -> Option<ProjectPath> {
         FantomeEntry::Readme => Utf8PathBuf::from("README.md"),
         FantomeEntry::License(file_name) => Utf8PathBuf::from(file_name),
         FantomeEntry::Image => Utf8PathBuf::from("thumbnail.webp"),
+        FantomeEntry::Hashtable(relative_path) => hashes_dir().join(relative_path),
         FantomeEntry::Info => return None,
     };
 
@@ -78,6 +79,12 @@ fn base_layer_dir() -> Utf8PathBuf {
 /// `content/base/raw`, as a project-relative path.
 fn raw_dir() -> Utf8PathBuf {
     ModProjectLayer::raw_content_path(Utf8Path::new(""))
+}
+
+/// `hashes`, as a project-relative path: where a project keeps its declared
+/// hashtable files, outside `content/`.
+fn hashes_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from(HASHES_DIR_NAME)
 }
 
 #[cfg(test)]

--- a/crates/ltk_mod_project/src/fantome/pack.rs
+++ b/crates/ltk_mod_project/src/fantome/pack.rs
@@ -8,7 +8,7 @@ use std::io::{self, Seek, Write};
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_fantome::{FantomeInfo, FantomeWriteError, FantomeWriter};
 
-use crate::{PackFormat, PackPlan, PackReporter};
+use crate::{PackFormat, PackFormatReport, PackPlan, PackReporter};
 
 /// Failure to encode a pack plan as a Fantome archive.
 ///
@@ -29,6 +29,15 @@ pub enum FantomePackError {
     /// The archive could not be written.
     #[error(transparent)]
     Write(#[from] FantomeWriteError),
+
+    /// Two different declared hashtable files land on one archive name.
+    ///
+    /// Tables land flat under `META/hashes/` by file name (a `hashes/` tail
+    /// is carried whole), so tables declared in different places can
+    /// collide. Refused rather than renamed: the author can rename a file;
+    /// a silently renamed table would ship under a name nobody chose.
+    #[error(transparent)]
+    DuplicateHashtableName(#[from] crate::DuplicateHashtableName),
 
     /// The thumbnail could not be read, or re-encoded as the PNG Fantome stores.
     #[error("Failed to convert the thumbnail {path}")]
@@ -90,14 +99,20 @@ impl<W> fmt::Debug for FantomeFormat<W> {
 impl<W: Write + Seek> PackFormat for FantomeFormat<W> {
     type Error = FantomePackError;
 
-    fn pack(self, plan: &PackPlan<'_>, progress: &mut PackReporter<'_>) -> Result<(), Self::Error> {
+    fn pack(
+        self,
+        plan: &PackPlan<'_>,
+        progress: &mut PackReporter<'_>,
+    ) -> Result<PackFormatReport, Self::Error> {
         let mut writer = FantomeWriter::new(self.writer);
 
         pack_base_layer(&mut writer, plan, progress)?;
         pack_metadata(&mut writer, plan)?;
 
         writer.finish()?;
-        Ok(())
+        // Nothing to trim: a fantome WAD stores hashes, not paths, so no
+        // stored name makes a table entry redundant.
+        Ok(PackFormatReport::default())
     }
 }
 
@@ -130,7 +145,25 @@ fn pack_metadata<W: Write + Seek>(
     writer: &mut FantomeWriter<W>,
     plan: &PackPlan<'_>,
 ) -> Result<(), FantomePackError> {
-    writer.write_info(&FantomeInfo::from(plan.project()))?;
+    // Where each planned table lands in the archive. Computed once, each
+    // route carrying its table: what the routes declare is what
+    // `info.hashtables` carries and what the entries below write, so the
+    // entries and the manifest cannot disagree. Two manifest entries may
+    // declare one file (one table, two shapes), which must stay one archive
+    // entry.
+    let routes = super::convert::fantome_routes(plan.hashtables())?;
+
+    let mut info = FantomeInfo::from(plan.project());
+    info.hashtables = routes.iter().map(|route| route.manifest.clone()).collect();
+
+    let mut written = std::collections::HashSet::new();
+    for route in &routes {
+        if written.insert(route.manifest.path.to_ascii_lowercase()) {
+            writer.write_hashtable(&route.manifest, route.planned.table())?;
+        }
+    }
+
+    writer.write_info(&info)?;
 
     if let Some(readme) = plan.readme() {
         let mut file =

--- a/crates/ltk_mod_project/src/fantome/tests.rs
+++ b/crates/ltk_mod_project/src/fantome/tests.rs
@@ -1151,3 +1151,575 @@ fn collect_files(root: &Utf8Path, dir: &Utf8Path, into: &mut Vec<Utf8PathBuf>) {
         }
     }
 }
+
+// -- hashtables --------------------------------------------------------------
+
+mod hashtables {
+    use ltk_hashtable::{Algorithm, Category};
+
+    use super::*;
+    use crate::{ModProjectHashtable, HASHES_DIR_NAME};
+
+    fn game_manifest() -> ModProjectHashtable {
+        ModProjectHashtable {
+            path: format!("{HASHES_DIR_NAME}/game.hashes.txt"),
+            category: Category::Game,
+            algorithm: Algorithm::Xxh64,
+            bits: 64,
+        }
+    }
+
+    /// A project tree declaring one `game` table holding `names`.
+    fn project_with_table(root: &Utf8Path, names: &str) -> ModProject {
+        write_project_tree(root);
+        std::fs::create_dir_all(root.join(HASHES_DIR_NAME)).unwrap();
+        std::fs::write(root.join(&game_manifest().path), names).unwrap();
+
+        ModProject {
+            hashtables: vec![game_manifest()],
+            ..test_project(None)
+        }
+    }
+
+    #[test]
+    fn pack_writes_the_declared_table_under_meta_hashes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp);
+        let project = project_with_table(&root, "ASSETS/Custom/One.tex\nassets/custom/two.tex\n");
+
+        let buffer = pack(&project, &root);
+        let mut archive = zip::ZipArchive::new(buffer).unwrap();
+
+        let mut table = String::new();
+        std::io::Read::read_to_string(
+            &mut archive.by_name("META/hashes/game.hashes.txt").unwrap(),
+            &mut table,
+        )
+        .unwrap();
+        assert_eq!(table, "ASSETS/Custom/One.tex\nassets/custom/two.tex\n");
+
+        let mut info_content = String::new();
+        std::io::Read::read_to_string(
+            &mut archive.by_name("META/info.json").unwrap(),
+            &mut info_content,
+        )
+        .unwrap();
+        let info: FantomeInfo = serde_json::from_str(&info_content).unwrap();
+        assert_eq!(info.hashtables.len(), 1);
+        assert_eq!(info.hashtables[0].path, "META/hashes/game.hashes.txt");
+        assert_eq!(info.hashtables[0].category, Category::Game);
+        assert_eq!(info.hashtables[0].bits, 64);
+    }
+
+    /// `hashes/` is outside `content/`, so the table file must never appear
+    /// as content - and `.modignore` must never touch it, even a rule that
+    /// ignores everything.
+    #[test]
+    fn the_table_is_not_content_and_never_meets_modignore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp);
+        let project = project_with_table(&root, "assets/custom/one.tex\n");
+        std::fs::write(root.join("content/.modignore"), "*\n").unwrap();
+
+        let buffer = pack(&project, &root);
+        let mut archive = zip::ZipArchive::new(buffer).unwrap();
+
+        assert!(archive.by_name("META/hashes/game.hashes.txt").is_ok());
+        let names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_owned())
+            .collect();
+        assert!(
+            !names.iter().any(|name| name.starts_with("WAD/")),
+            "the ignore-everything rule should have dropped all content: {names:?}"
+        );
+    }
+
+    /// A file under `hashes/` no manifest entry declares does not exist as
+    /// far as a pack is concerned.
+    #[test]
+    fn an_undeclared_table_file_is_not_packed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp);
+        write_project_tree(&root);
+        std::fs::create_dir_all(root.join(HASHES_DIR_NAME)).unwrap();
+        std::fs::write(
+            root.join(HASHES_DIR_NAME).join("game.hashes.txt"),
+            "assets/custom/one.tex\n",
+        )
+        .unwrap();
+
+        let buffer = pack(&test_project(None), &root);
+        let mut archive = zip::ZipArchive::new(buffer).unwrap();
+        assert!(archive.by_name("META/hashes/game.hashes.txt").is_err());
+    }
+
+    #[test]
+    fn pack_fails_on_a_missing_table_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp);
+        write_project_tree(&root);
+
+        let project = ModProject {
+            hashtables: vec![game_manifest()],
+            ..test_project(None)
+        };
+
+        match try_pack(&project, &root) {
+            Err(PackError::Hashtable { path, .. }) => {
+                assert_eq!(path, root.join(&game_manifest().path));
+            }
+            other => panic!("expected Hashtable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pack_fails_on_an_impossible_key_width() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp);
+        let mut project = project_with_table(&root, "assets/custom/one.tex\n");
+        project.hashtables[0].bits = 0;
+
+        match try_pack(&project, &root) {
+            Err(PackError::HashtableWidth { path, bits }) => {
+                assert_eq!(path, game_manifest().path);
+                assert_eq!(bits, 0);
+            }
+            other => panic!("expected HashtableWidth, got {other:?}"),
+        }
+    }
+
+    /// fnv1a_32("data/strings/name_1") and fnv1a_32("data/strings/name_50")
+    /// share their low 8 bits, so an 8-bit table holding both names makes one
+    /// of them unresolvable forever - which only the author can fix.
+    #[test]
+    fn pack_fails_on_a_key_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp);
+        let mut project = project_with_table(&root, "data/strings/name_1\ndata/strings/name_50\n");
+        project.hashtables[0].algorithm = Algorithm::Fnv1a32;
+        project.hashtables[0].bits = 8;
+
+        match try_pack(&project, &root) {
+            Err(PackError::HashtableCollision(collision)) => {
+                assert_eq!(collision.first, "data/strings/name_1");
+                assert_eq!(collision.second, "data/strings/name_50");
+            }
+            other => panic!("expected HashtableCollision, got {other:?}"),
+        }
+    }
+
+    /// User story 15: a round trip through an archive loses nothing - not
+    /// the names, not their casing, not the manifest.
+    #[test]
+    fn the_table_survives_project_archive_project_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp).join("project");
+        let project = project_with_table(&root, "ASSETS/Custom/One.tex\nassets/custom/two.tex\n");
+
+        let buffer = pack(&project, &root);
+
+        let extracted = utf8_dir(&tmp).join("extracted");
+        let imported = ProjectImporter::new(&extracted)
+            .import(FantomeImporter::new(buffer))
+            .unwrap();
+
+        assert_eq!(imported.hashtables, vec![game_manifest()]);
+        assert_eq!(
+            std::fs::read_to_string(extracted.join(&game_manifest().path)).unwrap(),
+            "ASSETS/Custom/One.tex\nassets/custom/two.tex\n"
+        );
+    }
+
+    /// An archive declaring a table, as the preserve writes one.
+    fn fantome_with_table(names: &str, packed_wad: Option<&[u8]>) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let cursor = Cursor::new(Vec::new());
+        let mut zip = ZipWriter::new(cursor);
+        let options = SimpleFileOptions::default();
+
+        zip.start_file("META/info.json", options).unwrap();
+        let info = r#"{
+            "Name": "Test Mod",
+            "Author": "Test Author",
+            "Version": "1.0.0",
+            "Description": "A test mod",
+            "Hashtables": [
+                {
+                    "Path": "META/hashes/game.hashes.txt",
+                    "Category": "game",
+                    "Algorithm": "xxh64",
+                    "Bits": 64
+                }
+            ]
+        }"#;
+        zip.write_all(info.as_bytes()).unwrap();
+
+        zip.start_file("META/hashes/game.hashes.txt", options)
+            .unwrap();
+        zip.write_all(names.as_bytes()).unwrap();
+
+        if let Some(wad) = packed_wad {
+            zip.start_file("WAD/Aatrox.wad.client", options).unwrap();
+            zip.write_all(wad).unwrap();
+        }
+
+        zip.finish().unwrap().into_inner()
+    }
+
+    /// A config path that climbs out of `hashes/` must not poison the
+    /// archive: the entry lands by its file name under `META/hashes/`, so
+    /// the result is one `FantomeReader::new` (which refuses any archive
+    /// holding an escaping entry name) will accept.
+    #[test]
+    fn a_climbing_config_path_packs_to_a_contained_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp).join("project");
+        write_project_tree(&root);
+        std::fs::create_dir_all(root.join(HASHES_DIR_NAME)).unwrap();
+        // Resolves to a real file beside the project, as the config says.
+        std::fs::write(utf8_dir(&tmp).join("evil.hashes.txt"), "assets/one.tex\n").unwrap();
+
+        let project = ModProject {
+            hashtables: vec![ModProjectHashtable {
+                path: format!("{HASHES_DIR_NAME}/../../evil.hashes.txt"),
+                ..game_manifest()
+            }],
+            ..test_project(None)
+        };
+
+        let buffer = pack(&project, &root);
+        let mut reader = ltk_fantome::FantomeReader::new(buffer).unwrap();
+        let info = reader.read_info().unwrap();
+        assert_eq!(info.hashtables[0].path, "META/hashes/evil.hashes.txt");
+
+        let tables = reader.read_hashtables().unwrap();
+        assert_eq!(tables[0].1.names().collect::<Vec<_>>(), ["assets/one.tex"]);
+    }
+
+    /// The whole-archive escape refusal covers table entries too: a hostile
+    /// manifest cannot steer an import, because the entry it has to point at
+    /// is refused at mount.
+    #[test]
+    fn an_archive_whose_table_entry_escapes_is_refused() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let cursor = Cursor::new(Vec::new());
+        let mut zip = ZipWriter::new(cursor);
+        let options = SimpleFileOptions::default();
+
+        zip.start_file("META/info.json", options).unwrap();
+        zip.write_all(
+            br#"{
+            "Name": "Test Mod",
+            "Author": "Test Author",
+            "Version": "1.0.0",
+            "Description": "A test mod",
+            "Hashtables": [
+                {
+                    "Path": "META/hashes/../../evil.hashes.txt",
+                    "Category": "game",
+                    "Algorithm": "xxh64",
+                    "Bits": 64
+                }
+            ]
+        }"#,
+        )
+        .unwrap();
+        zip.start_file("META/hashes/../../evil.hashes.txt", options)
+            .unwrap();
+        zip.write_all(b"assets/custom/one.tex\n").unwrap();
+        let archive = zip.finish().unwrap().into_inner();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let output = utf8_dir(&tmp).join("project");
+        let error = import(archive, &output).unwrap_err();
+        assert!(
+            matches!(
+                &error,
+                ImportError::Format(FantomeImportError::Extract(
+                    ltk_fantome::FantomeExtractError::EscapingEntry { .. }
+                ))
+            ),
+            "expected the mount-time refusal, got {error:?}"
+        );
+        assert!(!utf8_dir(&tmp).join("evil.hashes.txt").exists());
+    }
+
+    #[test]
+    fn import_writes_the_declared_table_into_hashes() {
+        let archive = fantome_with_table("assets/custom/one.tex\n", None);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let output = utf8_dir(&tmp);
+        let imported = import(archive, &output).unwrap();
+
+        assert_eq!(imported.hashtables, vec![game_manifest()]);
+        assert_eq!(
+            std::fs::read_to_string(output.join(&game_manifest().path)).unwrap(),
+            "assets/custom/one.tex\n"
+        );
+    }
+
+    /// User story 26: the mod's own table names its chunks, ahead of the
+    /// caller's resolver - here one that would claim every chunk.
+    #[test]
+    fn the_mods_own_table_names_its_packed_wad_chunks() {
+        let archive =
+            fantome_with_table("packed/file.bin\n", Some(&packed_wad_bytes(b"chunk bytes")));
+
+        let tmp = tempfile::tempdir().unwrap();
+        let output = utf8_dir(&tmp);
+        ProjectImporter::new(&output)
+            .import(FantomeImporter::new(Cursor::new(archive)).with_path_resolver(&FixedResolver))
+            .unwrap();
+
+        let named = output.join("content/base/Aatrox.wad.client/packed/file.bin");
+        assert_eq!(std::fs::read(&named).unwrap(), b"chunk bytes");
+        assert!(
+            !output
+                .join("content/base/Aatrox.wad.client/assets/characters/aatrox/skin0.bin")
+                .exists(),
+            "the caller's resolver must not outrank the mod's own table"
+        );
+    }
+
+    /// Tables land flat under `META/hashes/` by file name, so two different
+    /// table files can collide on one archive name. Refused rather than
+    /// renamed: a silently renamed table would ship under a name nobody
+    /// chose.
+    #[test]
+    fn colliding_table_file_names_fail_the_pack() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = utf8_dir(&tmp);
+        write_project_tree(&root);
+        std::fs::create_dir_all(root.join("hashes")).unwrap();
+        std::fs::create_dir_all(root.join("backup")).unwrap();
+        std::fs::write(root.join("hashes/game.hashes.txt"), "a/one.tex\n").unwrap();
+        std::fs::write(root.join("backup/game.hashes.txt"), "a/two.tex\n").unwrap();
+
+        let entry = |path: &str| ModProjectHashtable {
+            path: path.to_string(),
+            ..game_manifest()
+        };
+        let project = ModProject {
+            hashtables: vec![
+                entry("hashes/game.hashes.txt"),
+                entry("backup/game.hashes.txt"),
+            ],
+            ..test_project(None)
+        };
+
+        let err = try_pack(&project, &root).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PackError::Format(FantomePackError::DuplicateHashtableName(ref e))
+                    if e.destination() == "META/hashes/game.hashes.txt"
+                        && e.first() == "hashes/game.hashes.txt"
+                        && e.second() == "backup/game.hashes.txt"
+            ),
+            "Expected DuplicateHashtableName, got: {err}"
+        );
+    }
+
+    /// Two declared tables landing on one `hashes/` file name would clobber
+    /// each other on disk. An archive shaped like this is ambiguous, and an
+    /// import must refuse it rather than invent names.
+    #[test]
+    fn an_archive_with_colliding_table_names_fails_the_import() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let cursor = Cursor::new(Vec::new());
+        let mut zip = ZipWriter::new(cursor);
+        let options = SimpleFileOptions::default();
+
+        zip.start_file("META/info.json", options).unwrap();
+        let info = r#"{
+            "Name": "Test Mod",
+            "Author": "Test Author",
+            "Version": "1.0.0",
+            "Description": "A test mod",
+            "Hashtables": [
+                {
+                    "Path": "META/hashes/game.hashes.txt",
+                    "Category": "game",
+                    "Algorithm": "xxh64",
+                    "Bits": 64
+                },
+                {
+                    "Path": "OTHER/game.hashes.txt",
+                    "Category": "game",
+                    "Algorithm": "xxh64",
+                    "Bits": 64
+                }
+            ]
+        }"#;
+        zip.write_all(info.as_bytes()).unwrap();
+        zip.start_file("META/hashes/game.hashes.txt", options)
+            .unwrap();
+        zip.write_all(b"a/one.tex\n").unwrap();
+        zip.start_file("OTHER/game.hashes.txt", options).unwrap();
+        zip.write_all(b"a/two.tex\n").unwrap();
+        let archive = zip.finish().unwrap().into_inner();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let output = utf8_dir(&tmp);
+        let err = import(archive, &output).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ImportError::Format(FantomeImportError::DuplicateHashtableName(ref e))
+                    if e.destination() == "hashes/game.hashes.txt"
+                        && e.first() == "META/hashes/game.hashes.txt"
+                        && e.second() == "OTHER/game.hashes.txt"
+            ),
+            "Expected DuplicateHashtableName, got: {err}"
+        );
+    }
+
+    /// A planned table declared at `path`, for driving the mapping directly.
+    fn planned_table(path: &str) -> crate::pack::PlannedHashtable {
+        crate::pack::PlannedHashtable::new(
+            Utf8PathBuf::from(path),
+            ltk_hashtable::HashtableEntry::new(
+                path,
+                Category::Game,
+                Algorithm::Xxh64,
+                ltk_hashtable::KeyWidth::new(64).unwrap(),
+            ),
+            ltk_hashtable::Hashtable::from_names(["a/one.tex"]).unwrap(),
+        )
+    }
+
+    /// A table already under `hashes/` keeps its tail; one declared
+    /// elsewhere lands by its file name; one file declared twice stays one
+    /// archive entry - and each route carries the table it was mapped from.
+    #[test]
+    fn tables_declared_outside_hashes_land_by_file_name() {
+        use super::super::convert::fantome_routes;
+
+        let planned = [
+            planned_table("tables/binhashes.hashes.txt"),
+            planned_table("hashes/game.hashes.txt"),
+            planned_table("hashes/game.hashes.txt"),
+        ];
+
+        let routes = fantome_routes(&planned).unwrap();
+        let paths: Vec<&str> = routes
+            .iter()
+            .map(|route| route.manifest.path.as_str())
+            .collect();
+        assert_eq!(
+            paths,
+            [
+                "META/hashes/binhashes.hashes.txt",
+                "META/hashes/game.hashes.txt",
+                "META/hashes/game.hashes.txt",
+            ]
+        );
+        for (route, planned) in routes.iter().zip(&planned) {
+            assert_eq!(route.planned, planned, "a route carries its own table");
+        }
+    }
+
+    /// Two different files landing on one archive name are refused, not
+    /// renamed - a renamed table would ship under a name nobody chose.
+    #[test]
+    fn two_files_landing_on_one_archive_name_are_refused() {
+        use super::super::convert::fantome_routes;
+
+        let planned = [
+            planned_table("tables/game.hashes.txt"),
+            planned_table("hashes/game.hashes.txt"),
+        ];
+
+        let err = fantome_routes(&planned).unwrap_err();
+        assert_eq!(err.destination(), "META/hashes/game.hashes.txt");
+        assert_eq!(err.first(), "tables/game.hashes.txt");
+        assert_eq!(err.second(), "hashes/game.hashes.txt");
+    }
+
+    /// The import-direction mapping: a `META/hashes/` tail keeps its subpath,
+    /// a table elsewhere lands by file name, one file declared twice stays
+    /// one file, and an entry no key width fits is dropped (its table cannot
+    /// be read out of the archive).
+    #[test]
+    fn archive_manifests_map_to_project_paths() {
+        use ltk_fantome::FantomeHashtable;
+
+        use super::super::convert::project_routes;
+
+        let entry = |path: &str, bits| FantomeHashtable {
+            path: path.to_owned(),
+            category: Category::Game,
+            algorithm: Algorithm::Xxh64,
+            bits,
+        };
+
+        let routes = project_routes(&[
+            entry("META/hashes/sub/game.hashes.txt", 64),
+            entry("ELSEWHERE/game.hashes.txt", 64),
+            entry("META/hashes/sub/game.hashes.txt", 64),
+            entry("META/hashes/broken.hashes.txt", 0),
+        ])
+        .unwrap();
+
+        let paths: Vec<&str> = routes
+            .iter()
+            .map(|route| route.manifest.path.as_str())
+            .collect();
+        assert_eq!(
+            paths,
+            [
+                "hashes/sub/game.hashes.txt",
+                "hashes/game.hashes.txt",
+                "hashes/sub/game.hashes.txt",
+            ]
+        );
+    }
+
+    /// The mapping is where escape-proofing lives, whoever calls it: a tail
+    /// that climbs, re-roots, or smuggles a platform separator lands by its
+    /// file name, never as declared.
+    #[test]
+    fn a_traversing_manifest_path_maps_to_a_plain_project_path() {
+        use ltk_fantome::FantomeHashtable;
+
+        use super::super::convert::project_routes;
+
+        let entry = |path: &str| FantomeHashtable {
+            path: path.to_owned(),
+            category: Category::Game,
+            algorithm: Algorithm::Xxh64,
+            bits: 64,
+        };
+
+        let routes = project_routes(&[
+            entry("META/hashes/../../evil.hashes.txt"),
+            entry("META/hashes/sub/../evil2.hashes.txt"),
+            entry(r"META/hashes/sub\evil3.hashes.txt"),
+        ])
+        .unwrap();
+
+        let paths: Vec<&str> = routes
+            .iter()
+            .map(|route| route.manifest.path.as_str())
+            .collect();
+        assert_eq!(
+            paths,
+            [
+                "hashes/evil.hashes.txt",
+                "hashes/evil2.hashes.txt",
+                // The whole final component: `\` is not a separator here.
+                "hashes/unnamed.hashes.txt",
+            ]
+        );
+    }
+}

--- a/crates/ltk_mod_project/src/hashtable_routes.rs
+++ b/crates/ltk_mod_project/src/hashtable_routes.rs
@@ -1,0 +1,151 @@
+//! Routing hashtable declarations between a container and the project,
+//! shared by the fantome and modpkg sides.
+//!
+//! A route maps one declared table to where it lands on the other side. The
+//! pieces of that story live here: the escape-proofed placement rules
+//! ([`is_plain_tail`], [`file_name_of`]), the one-destination-per-source
+//! rule ([`NameClaims`], refusing with [`DuplicateHashtableName`]), and the
+//! two pairing shapes the directions produce - [`HashtableRoute`] for an
+//! import's keyed join against what it reads out of the archive,
+//! [`PlannedRoute`] for a pack's by-construction pairing with the plan's
+//! tables. Each container module owns its own placement rule and builds its
+//! own manifest type; what is identical across containers is here.
+
+use std::collections::HashMap;
+
+use camino::Utf8Path;
+
+/// Whether a tail can be carried under the destination directory as it is:
+/// nothing but plain path components, so a manifest cannot steer a write
+/// with `..`, an absolute path, a drive prefix or a backslash. A tail that
+/// fails this lands by its file name instead.
+///
+/// The backslash and colon checks are byte checks rather than component
+/// checks on purpose: what counts as a separator or a prefix differs by
+/// platform, and a mapped path must mean the same file everywhere.
+pub(crate) fn is_plain_tail(tail: &str) -> bool {
+    !tail.is_empty()
+        && !tail.contains(['\\', ':'])
+        && Utf8Path::new(tail)
+            .components()
+            .all(|component| matches!(component, camino::Utf8Component::Normal(_)))
+}
+
+/// The final `/`-separated component of `path`.
+///
+/// For a table declared outside the conventional directory (or one whose
+/// tail cannot be carried). Split on `/` alone rather than
+/// [`Utf8Path::file_name`], which reads `\` as a separator on Windows only -
+/// the mapping must answer the same on every platform. The constant is the
+/// last resort for a path with no usable final component - all but
+/// unreachable, but a mapping used by conversions has to be total.
+pub(crate) fn file_name_of(path: &str) -> &str {
+    path.rsplit('/')
+        .next()
+        .filter(|name| is_plain_tail(name))
+        .unwrap_or("unnamed.hashes.txt")
+}
+
+/// Two different hashtable files land on one destination name.
+///
+/// Conversions flatten manifest-declared table paths into one destination
+/// directory, so tables declared in different places can collide on a file
+/// name. The colliding pair is refused rather than renamed: on a pack the
+/// author can rename a file; on an import an ambiguous archive must not be
+/// guessed at (and writing both would clobber one with the other).
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("hashtable files {first} and {second} both land on {destination}")]
+pub struct DuplicateHashtableName {
+    destination: String,
+    first: String,
+    second: String,
+}
+
+impl DuplicateHashtableName {
+    /// The destination path both declarations land on.
+    pub fn destination(&self) -> &str {
+        &self.destination
+    }
+
+    /// The declared path of the first table to land there.
+    pub fn first(&self) -> &str {
+        &self.first
+    }
+
+    /// The declared path of the second table, the one that collided.
+    pub fn second(&self) -> &str {
+        &self.second
+    }
+}
+
+/// One hashtable declaration's mapping: the path it was declared at, and
+/// the manifest entry it becomes on the other side.
+///
+/// The pairing is the mapping's one guarantee: whoever writes the mapped
+/// files pairs what it read at `source` with where `manifest` lands, so the
+/// written files and the written manifest cannot drift.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HashtableRoute<M> {
+    /// The declared path the entry was mapped from.
+    pub(crate) source: String,
+    /// The manifest entry it becomes, holding the destination path.
+    pub(crate) manifest: M,
+}
+
+/// One planned table's mapping: the container manifest entry it becomes,
+/// attached to the planned table it declares.
+///
+/// Built in one pass over the plan, so a manifest entry cannot be paired
+/// with another table's content - there is no second sequence to correlate.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PlannedRoute<'a, M> {
+    /// The container manifest entry, holding the destination path.
+    pub(crate) manifest: M,
+    /// The planned table the entry declares.
+    pub(crate) planned: &'a crate::pack::PlannedHashtable,
+}
+
+/// Claims destination paths for the manifest mappings, one per source file.
+///
+/// One source path always gets one answer, so a file two manifest entries
+/// declare stays one file; a *different* source whose tail lands on a
+/// claimed path is a [`DuplicateHashtableName`] error. Destinations compare
+/// case-insensitively, matching how archive entries are looked up; sources
+/// compare exactly, so case-variant spellings of one path count as two
+/// files (whether they are one file is the filesystem's secret, and an
+/// ambiguous pair must not pack differently on different platforms).
+#[derive(Default)]
+pub(crate) struct NameClaims {
+    /// Lowercased destination path, to the source path that claimed it.
+    claimed: HashMap<String, String>,
+}
+
+impl NameClaims {
+    /// `{dir}/{tail}`, unless a different source already claimed it.
+    ///
+    /// # Errors
+    ///
+    /// [`DuplicateHashtableName`] when the destination is claimed by a
+    /// different source path.
+    pub(crate) fn claim(
+        &mut self,
+        dir: &str,
+        tail: &str,
+        source: &str,
+    ) -> Result<String, DuplicateHashtableName> {
+        let destination = format!("{dir}/{tail}");
+        match self.claimed.get(&destination.to_ascii_lowercase()) {
+            Some(claimant) if claimant != source => Err(DuplicateHashtableName {
+                destination,
+                first: claimant.clone(),
+                second: source.to_owned(),
+            }),
+            Some(_) => Ok(destination),
+            None => {
+                self.claimed
+                    .insert(destination.to_ascii_lowercase(), source.to_owned());
+                Ok(destination)
+            }
+        }
+    }
+}

--- a/crates/ltk_mod_project/src/lib.rs
+++ b/crates/ltk_mod_project/src/lib.rs
@@ -14,14 +14,20 @@ mod modignore;
 pub mod pack;
 mod package_format;
 
+#[cfg(any(feature = "fantome", feature = "modpkg"))]
+mod hashtable_routes;
+
 #[cfg(feature = "fantome")]
 pub mod fantome;
 #[cfg(feature = "modpkg")]
 pub mod modpkg;
+#[cfg(feature = "fantome")]
+pub mod preserve;
 
 pub use cancellation::Cancellation;
 pub use config_format::ConfigFormat;
 pub use error::{ModProjectError, SerializeError};
+pub use hashtable_routes::DuplicateHashtableName;
 pub use import::{
     ConfigRefusal, ImportError, ImportFormat, ImportProgress, ImportReporter, ImportStage,
     ImportTarget, NoConfig, ProjectImporter, ProjectPath, ProjectPaths,
@@ -32,13 +38,23 @@ pub use modignore::{
     MODIGNORE_FILE_NAME,
 };
 pub use pack::{
-    IgnoreMode, PackError, PackFormat, PackOptions, PackPlan, PackProgress, PackReport,
-    PackReporter, PackStage, PlannedFile, PlannedLayer, PlannedLicense, ProjectPacker,
+    IgnoreMode, PackError, PackFormat, PackFormatReport, PackOptions, PackPlan, PackProgress,
+    PackReport, PackReporter, PackStage, PlannedFile, PlannedHashtable, PlannedLayer,
+    PlannedLicense, ProjectPacker,
 };
 pub use package_format::PackageFormat;
+#[cfg(feature = "fantome")]
+pub use preserve::{preserve_archive_names, HarvestReport, PreserveError, PreserveOutcome};
 
 /// The directory every layer's content sits under, in the project root.
 pub const CONTENT_DIR_NAME: &str = "content";
+
+/// The directory a project's declared hashtable files sit under, in the
+/// project root.
+///
+/// Deliberately outside [`CONTENT_DIR_NAME`]: a table is never a packing
+/// candidate and never meets `.modignore`.
+pub const HASHES_DIR_NAME: &str = "hashes";
 
 /// Well-known mod tags for common mod categories.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -303,6 +319,16 @@ pub struct ModProject {
     /// Example: `thumbnail.webp`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thumbnail: Option<String>,
+
+    /// The embedded hashtables the project declares.
+    ///
+    /// The manifest is authoritative: a file under `hashes/` no entry here
+    /// declares does not exist for lookup. By convention the files live at
+    /// `hashes/{category}.hashes.txt` (see [`HASHES_DIR_NAME`]), but each
+    /// entry's `path` is what says where its table is. Omitted when empty so
+    /// a project without tables serializes as before this field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hashtables: Vec<ModProjectHashtable>,
 }
 
 impl ModProject {
@@ -410,6 +436,52 @@ impl ModProject {
         };
 
         result.map_err(|source| ModProjectError::Serialize { format, source })
+    }
+}
+
+/// One `hashtables` manifest entry in a mod project config.
+///
+/// The project spelling of `ltk_hashtable`'s
+/// [`HashtableEntry`](ltk_hashtable::HashtableEntry): lowercase
+/// keys, `path` relative to the project root. Convert with
+/// [`ModProjectHashtable::to_entry`] and [`ModProjectHashtable::from_entry`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ModProjectHashtable {
+    /// Where the table file lives, relative to the project root.
+    ///
+    /// Example: `hashes/game.hashes.txt`
+    pub path: String,
+    /// The lookup domain of the table's names.
+    pub category: ltk_hashtable::Category,
+    /// The hash function keying the table's names.
+    pub algorithm: ltk_hashtable::Algorithm,
+    /// The declared key width in bits.
+    pub bits: u8,
+}
+
+impl ModProjectHashtable {
+    /// The entry as `ltk_hashtable`'s domain type.
+    ///
+    /// `None` when `bits` declares a width no key can have; the standard
+    /// requires `1..=64`.
+    pub fn to_entry(&self) -> Option<ltk_hashtable::HashtableEntry> {
+        let width = ltk_hashtable::KeyWidth::new(self.bits)?;
+        Some(ltk_hashtable::HashtableEntry::new(
+            self.path.as_str(),
+            self.category.clone(),
+            self.algorithm.clone(),
+            width,
+        ))
+    }
+
+    /// Spell a domain entry the project way.
+    pub fn from_entry(entry: &ltk_hashtable::HashtableEntry) -> Self {
+        Self {
+            path: entry.path().to_string(),
+            category: entry.category().clone(),
+            algorithm: entry.algorithm().clone(),
+            bits: entry.width().bits(),
+        }
     }
 }
 

--- a/crates/ltk_mod_project/src/modpkg/convert.rs
+++ b/crates/ltk_mod_project/src/modpkg/convert.rs
@@ -15,7 +15,13 @@ use ltk_modpkg::{
     ModpkgMetadata,
 };
 
-use crate::{ModMap, ModProject, ModProjectAuthor, ModProjectLayer, ModProjectLicense, ModTag};
+use camino::Utf8Path;
+
+use crate::hashtable_routes::{file_name_of, is_plain_tail, NameClaims, PlannedRoute};
+use crate::{
+    ModMap, ModProject, ModProjectAuthor, ModProjectHashtable, ModProjectLayer, ModProjectLicense,
+    ModTag, HASHES_DIR_NAME,
+};
 
 /// Read the project a mounted `.modpkg` describes.
 ///
@@ -73,8 +79,81 @@ impl From<&ModpkgMetadata> for ModProject {
             transformers: vec![],
             layers,
             thumbnail: None,
+            hashtables: project_hashtables(metadata.hashtables()),
         }
     }
+}
+
+/// The project manifest a package's `hashtables` declarations become.
+///
+/// Each path is rewritten to where the extractor writes the file, by the
+/// package format's own placement rule ([`ltk_modpkg::hashtable_file_name`]),
+/// so the written files and the written manifest cannot drift. An entry
+/// whose chunk the extractor plans nothing for - one declared outside
+/// `_meta_/hashes/` - is dropped with it: keeping the declaration would
+/// declare a file the import never writes.
+///
+/// An entry whose declared width no key can have is dropped too, mirroring
+/// the fantome side: `PackPlan::hashtables()` refuses an impossible width,
+/// so carrying it would import a project that cannot pack.
+pub(crate) fn project_hashtables(
+    declared: &[ltk_modpkg::ModpkgHashtable],
+) -> Vec<ModProjectHashtable> {
+    declared
+        .iter()
+        .filter(|manifest| manifest.to_entry().is_some())
+        .filter_map(|manifest| {
+            let file_name = ltk_modpkg::hashtable_file_name(&manifest.path)?;
+            Some(ModProjectHashtable {
+                path: format!("{HASHES_DIR_NAME}/{file_name}"),
+                category: manifest.category.clone(),
+                algorithm: manifest.algorithm.clone(),
+                bits: manifest.bits,
+            })
+        })
+        .collect()
+}
+
+/// Where each planned table lands in the package, paired with its table.
+///
+/// Every planned table maps, verbatim except for the path. A path directly
+/// under `hashes/` keeps its file name beneath `_meta_/hashes/`, so pack,
+/// import, pack again keeps every table where it was; a table declared
+/// elsewhere (or nested) lands under `_meta_/hashes/` by its file name -
+/// `ModpkgBuilder::with_hashtable` takes nothing deeper.
+///
+/// # Errors
+///
+/// [`DuplicateHashtableName`](crate::DuplicateHashtableName) when two
+/// different declared files land on one chunk name - refused rather than
+/// renamed, since the author can rename a file and a silently renamed table
+/// would ship under a name nobody chose.
+pub(crate) fn modpkg_routes(
+    planned: &[crate::pack::PlannedHashtable],
+) -> Result<Vec<PlannedRoute<'_, ltk_modpkg::ModpkgHashtable>>, crate::DuplicateHashtableName> {
+    let mut claims = NameClaims::default();
+    planned
+        .iter()
+        .map(|planned| {
+            let source = planned.entry().path();
+            let file_name = source
+                .strip_prefix(HASHES_DIR_NAME)
+                .ok()
+                .map(Utf8Path::as_str)
+                .filter(|tail| is_plain_tail(tail) && !tail.contains('/'))
+                .unwrap_or_else(|| file_name_of(source.as_str()));
+            let mapped = ltk_modpkg::ModpkgHashtable {
+                path: claims.claim(ltk_modpkg::HASHTABLES_CHUNK_DIR, file_name, source.as_str())?,
+                category: planned.entry().category().clone(),
+                algorithm: planned.entry().algorithm().clone(),
+                bits: planned.entry().width().bits(),
+            };
+            Ok(PlannedRoute {
+                manifest: mapped,
+                planned,
+            })
+        })
+        .collect()
 }
 
 /// The layer table a package declares, joining its header against its metadata.

--- a/crates/ltk_mod_project/src/modpkg/format.rs
+++ b/crates/ltk_mod_project/src/modpkg/format.rs
@@ -16,7 +16,8 @@ use ltk_modpkg::{
 
 use super::thumbnail::{load_thumbnail, ThumbnailError};
 use crate::{
-    ModProjectAuthor, ModProjectLicense, PackFormat, PackPlan, PackReporter, PlannedLayer,
+    ModProjectAuthor, ModProjectLicense, PackFormat, PackFormatReport, PackPlan, PackReporter,
+    PlannedLayer,
 };
 
 /// Failure to encode a pack plan as a `.modpkg` archive.
@@ -52,6 +53,15 @@ pub enum ModpkgPackError {
     #[error(transparent)]
     Thumbnail(#[from] ThumbnailError),
 
+    /// Two different declared hashtable files land on one archive name.
+    ///
+    /// Tables land flat under `_meta_/hashes/` by file name, so tables
+    /// declared in different places can collide. Refused rather than
+    /// renamed: the author can rename a file; a silently renamed table
+    /// would ship under a name nobody chose.
+    #[error(transparent)]
+    DuplicateHashtableName(#[from] crate::DuplicateHashtableName),
+
     /// Two planned files resolve to the same chunk: same WAD-relative path,
     /// layer, and WAD. Chunk paths are case-insensitive, so paths that differ
     /// only by case collide.
@@ -76,8 +86,11 @@ impl ModpkgPackError {
 /// Packs a mod project into a `.modpkg` archive; the modpkg backend for
 /// [`ProjectPacker`](crate::ProjectPacker).
 ///
-/// All layers are stored. See the
-/// [`pack` module docs](crate::pack) for how formats plug into the driver.
+/// All layers are stored. The plan's hashtables are stored as `_meta_/hashes/`
+/// chunks the metadata declares (schema version 3), each keeping the file
+/// name the project kept it at.
+/// See the [`pack` module docs](crate::pack) for how formats plug into the
+/// driver.
 ///
 /// # Example
 ///
@@ -108,10 +121,10 @@ impl<W: Write + Seek> ModpkgFormat<W> {
     }
 
     /// Turn the plan into a configured `ModpkgBuilder` plus a map from chunk
-    /// keys to source file paths.
+    /// keys to source file paths, and how many `game` names the trim dropped.
     fn configure_builder(
         plan: &PackPlan<'_>,
-    ) -> Result<(ModpkgBuilder, ChunkFileMap), ModpkgPackError> {
+    ) -> Result<(ModpkgBuilder, ChunkFileMap, usize), ModpkgPackError> {
         let mut builder = ModpkgBuilder::default();
 
         // Layers
@@ -131,13 +144,69 @@ impl<W: Write + Seek> ModpkgFormat<W> {
         // Metadata
         builder = builder.with_metadata(ModpkgMetadata::try_from(plan)?);
 
+        // Hashtables. Each planned table maps to where it lands in the
+        // package, each route carrying its table. Every declaration is
+        // kept: two manifest entries may declare one file (one table, two
+        // shapes), which stays one chunk carrying both entries in the
+        // metadata - `with_hashtable` holds that pairing.
+        let routes = super::convert::modpkg_routes(plan.hashtables())?;
+        let stored_paths: Vec<&str> = plan
+            .layers()
+            .iter()
+            .flat_map(|layer| layer.files().iter().map(|file| file.rel_path()))
+            .collect();
+        let mut declarations_per_chunk: HashMap<String, usize> = HashMap::new();
+        for route in &routes {
+            *declarations_per_chunk
+                .entry(route.manifest.path.to_ascii_lowercase())
+                .or_insert(0) += 1;
+        }
+        let mut trimmed_game_names = 0;
+        for route in &routes {
+            // Trim only a chunk with a single declaration: a shared chunk's
+            // bytes serve every shape declaring it, and a name only one
+            // shape finds redundant must survive for the others.
+            let chunk_key = route.manifest.path.to_ascii_lowercase();
+            let (table, dropped) = if declarations_per_chunk[&chunk_key] == 1 {
+                trim_game_table(route.planned.table(), route.planned.entry(), &stored_paths)
+            } else {
+                (route.planned.table().clone(), 0)
+            };
+            trimmed_game_names += dropped;
+            // Every declaration serializes its own planned table, so the
+            // builder sees what each one declares and can refuse a chunk
+            // declared over two different tables.
+            let mut bytes = Vec::new();
+            table
+                .write_to(&mut bytes)
+                .map_err(|error| ModpkgPackError::Builder(error.into()))?;
+            builder = builder
+                .with_hashtable(route.manifest.clone(), bytes)
+                .map_err(ModpkgPackError::Builder)?;
+        }
+
         // Content chunks
         let mut file_map = ChunkFileMap::new();
         for planned in plan.layers() {
             let layer_name = planned.layer().name.as_str();
             for entry in planned.files() {
-                let mut cb = ModpkgChunkBuilder::new()
-                    .with_path(entry.rel_path())
+                let rel_path = entry.rel_path();
+                // The escape hatch, packing side: an extraction that cannot
+                // name a chunk writes it at the WAD root under the hex of its
+                // path hash, so a WAD-root file whose stem is exactly that
+                // width is the raw hash, not a path. Only the WAD root - a
+                // hex-looking name inside a directory is a real path.
+                let mut cb = ModpkgChunkBuilder::new();
+                cb = if entry.wad().is_some()
+                    && !rel_path.contains('/')
+                    && ltk_modpkg::PathHash::from_hex_name(rel_path).is_some()
+                {
+                    cb.with_hashed_chunk_name(rel_path)
+                        .expect("a name from_hex_name accepts is one with_hashed_chunk_name takes")
+                } else {
+                    cb.with_path(rel_path)
+                };
+                cb = cb
                     .with_compression(ModpkgCompression::for_extension(entry.source().extension()))
                     .with_layer(layer_name);
 
@@ -172,8 +241,48 @@ impl<W: Write + Seek> ModpkgFormat<W> {
             builder = builder.with_thumbnail(load_thumbnail(thumbnail)?);
         }
 
-        Ok((builder, file_map))
+        Ok((builder, file_map, trimmed_game_names))
     }
+}
+
+/// `table` with the names the package's own chunk table already recovers
+/// removed, and how many were removed.
+///
+/// The predicate is `key(name) == key(stored chunk path)`, well defined
+/// because both sides are the same shape: a `game` name is a path relative to
+/// the WAD root, which is what a chunk's stored path holds. The stored path
+/// keeps its authored casing (ADR 0003) and is the trimmed name's surviving
+/// copy, which is what makes the trim safe.
+///
+/// `game` only: nothing in a package deduces a `binentries` or `binhashes`
+/// name, so trimming any other category would simply delete it. Any other
+/// category's table comes back whole.
+fn trim_game_table(
+    table: &ltk_hashtable::Hashtable,
+    entry: &ltk_hashtable::HashtableEntry,
+    stored_paths: &[&str],
+) -> (ltk_hashtable::Hashtable, usize) {
+    if *entry.category() != ltk_hashtable::Category::Game {
+        return (table.clone(), 0);
+    }
+
+    let stored: std::collections::HashSet<ltk_hashtable::Key> = stored_paths
+        .iter()
+        .filter_map(|path| ltk_hashtable::Key::of(path, entry.algorithm(), entry.width()))
+        .collect();
+
+    let kept: Vec<&str> = table
+        .names()
+        .filter(|name| {
+            !ltk_hashtable::Key::of(name, entry.algorithm(), entry.width())
+                .is_some_and(|key| stored.contains(&key))
+        })
+        .collect();
+    let dropped = table.names().count() - kept.len();
+
+    let trimmed = ltk_hashtable::Hashtable::from_names(kept)
+        .expect("names kept from a validated table are still valid");
+    (trimmed, dropped)
 }
 
 impl<W> fmt::Debug for ModpkgFormat<W> {
@@ -189,8 +298,8 @@ impl<W: Write + Seek> PackFormat for ModpkgFormat<W> {
         mut self,
         plan: &PackPlan<'_>,
         progress: &mut PackReporter<'_>,
-    ) -> Result<(), Self::Error> {
-        let (builder, file_map) = Self::configure_builder(plan)?;
+    ) -> Result<PackFormatReport, Self::Error> {
+        let (builder, file_map, trimmed_game_names) = Self::configure_builder(plan)?;
 
         builder
             .build_to_writer(&mut self.writer, |chunk_builder| {
@@ -214,7 +323,10 @@ impl<W: Write + Seek> PackFormat for ModpkgFormat<W> {
             })
             .map_err(ModpkgPackError::Builder)?;
 
-        Ok(())
+        Ok(PackFormatReport {
+            trimmed_game_names,
+            ..PackFormatReport::default()
+        })
     }
 }
 
@@ -252,6 +364,10 @@ impl TryFrom<&PackPlan<'_>> for ModpkgMetadata {
                 .iter()
                 .map(ModpkgLayerMetadata::from)
                 .collect(),
+            // The builder owns the hashtable manifest: `with_hashtable`
+            // declares each table, so declaration and stored chunk cannot
+            // disagree.
+            hashtables: vec![],
         })
     }
 }

--- a/crates/ltk_mod_project/src/modpkg/import.rs
+++ b/crates/ltk_mod_project/src/modpkg/import.rs
@@ -42,7 +42,10 @@ pub enum ModpkgImportError {
 ///
 /// A package stores its chunks under the paths they were packed from, so there
 /// is nothing to name and no counterpart here to the Fantome importer's
-/// resolver and naming policy.
+/// resolver and naming policy. The declared hashtables come back too: the
+/// extractor writes them under `hashes/` by the package format's own
+/// placement rule, and the recovered project manifest maps each declared
+/// entry through that same rule, so the files and the manifest agree.
 ///
 /// The progress unit is the layer: a package's content extracts to `content/`
 /// whole rather than a WAD at a time, and the layer is the largest step an
@@ -184,5 +187,8 @@ fn project_path(planned: &PlannedChunk<'_>) -> ProjectPath {
         // The meta chunks are the project's root files, beside `content/`
         // rather than inside it.
         ChunkDestination::Root(file_name) => ProjectPath::file(file_name),
+        // A hashtable lands under `hashes/` beside `content/`, which is
+        // exactly where the destination composes it.
+        ChunkDestination::Hashtable { .. } => ProjectPath::file(planned.destination.compose()),
     }
 }

--- a/crates/ltk_mod_project/src/modpkg/tests.rs
+++ b/crates/ltk_mod_project/src/modpkg/tests.rs
@@ -695,6 +695,454 @@ fn a_project_converted_from_metadata_reads_a_custom_license() {
     );
 }
 
+// -- embedded hashtables ----------------------------------------------------
+
+fn game_table_project(root: &Utf8Path, names: &str) -> ModProject {
+    fs::create_dir_all(root.join("hashes")).unwrap();
+    fs::write(root.join("hashes/game.hashes.txt"), names).unwrap();
+
+    ModProject {
+        hashtables: vec![crate::ModProjectHashtable {
+            path: "hashes/game.hashes.txt".to_string(),
+            category: ltk_hashtable::Category::Game,
+            algorithm: ltk_hashtable::Algorithm::Xxh64,
+            bits: 64,
+        }],
+        ..test_mod_project(vec![ModProjectLayer::base()])
+    }
+}
+
+/// The declared table becomes a chunk the package's metadata declares, at
+/// `_meta_/hashes/` under the file name the project kept it at.
+#[test]
+fn pack_embeds_the_declared_hashtables() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(&root, "base", "Test.wad.client/data.bin", b"content");
+    let names = "ASSETS/Custom/One.tex\nASSETS/Custom/Two.tex\n";
+
+    let (mut modpkg, _) = pack(game_table_project(&root, names), &root);
+
+    let tables = modpkg.load_hashtables().unwrap();
+    assert_eq!(tables.len(), 1);
+    let (entry, table) = &tables[0];
+    assert_eq!(entry.path(), "_meta_/hashes/game.hashes.txt");
+    assert_eq!(
+        table.names().collect::<Vec<_>>(),
+        ["ASSETS/Custom/One.tex", "ASSETS/Custom/Two.tex"]
+    );
+}
+
+/// User story 34: project -> modpkg -> project loses no table names and no
+/// casing. The file comes back under `hashes/` and the imported
+/// `mod.config.json` declares it where it landed.
+#[test]
+fn hashtables_survive_a_pack_import_round_trip() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(&root, "base", "Test.wad.client/data.bin", b"content");
+    let names = "ASSETS/Custom/CasedName.tex\n";
+
+    let mut buffer = Cursor::new(Vec::new());
+    ProjectPacker::new(game_table_project(&root, names), root.to_owned())
+        .pack(ModpkgFormat::new(&mut buffer))
+        .unwrap();
+
+    let output = utf8_tempdir(&tmp).join("imported");
+    let imported = import(buffer.into_inner(), &output);
+
+    assert_eq!(
+        fs::read_to_string(output.join("hashes/game.hashes.txt")).unwrap(),
+        names
+    );
+    assert_eq!(
+        imported.hashtables,
+        [crate::ModProjectHashtable {
+            path: "hashes/game.hashes.txt".to_string(),
+            category: ltk_hashtable::Category::Game,
+            algorithm: ltk_hashtable::Algorithm::Xxh64,
+            bits: 64,
+        }]
+    );
+}
+
+/// User story 35: a modpkg converted to a fantome archive carries its tables
+/// as `META/hashes/` entries the info.json declares. There is no direct
+/// converter - the path is modpkg -> project -> fantome - so this holds the
+/// whole chain together.
+#[cfg(feature = "fantome")]
+#[test]
+fn a_modpkg_converted_through_a_project_carries_its_tables_to_fantome() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(&root, "base", "Test.wad.client/data.bin", b"content");
+    let names = "ASSETS/Custom/CasedName.tex\n";
+
+    let mut buffer = Cursor::new(Vec::new());
+    ProjectPacker::new(game_table_project(&root, names), root.to_owned())
+        .pack(ModpkgFormat::new(&mut buffer))
+        .unwrap();
+
+    let output = utf8_tempdir(&tmp).join("imported");
+    let imported = import(buffer.into_inner(), &output);
+
+    let mut fantome_buffer = Cursor::new(Vec::new());
+    ProjectPacker::new(imported, output)
+        .pack(crate::fantome::FantomeFormat::new(&mut fantome_buffer))
+        .unwrap();
+
+    fantome_buffer.set_position(0);
+    let mut reader = ltk_fantome::FantomeReader::new(fantome_buffer).unwrap();
+    let tables = reader.read_hashtables().unwrap();
+    assert_eq!(tables.len(), 1);
+    let (entry, table) = &tables[0];
+    assert_eq!(entry.path(), "META/hashes/game.hashes.txt");
+    assert_eq!(
+        table.names().collect::<Vec<_>>(),
+        ["ASSETS/Custom/CasedName.tex"]
+    );
+}
+
+/// The trim: a `game` name whose key the package's own chunk table already
+/// recovers is not stored twice. Judged on keys, so a name that differs from
+/// the stored path only in case is still redundant - the stored path (which
+/// keeps its authored casing since ADR 0003) is the surviving copy.
+#[test]
+fn pack_trims_game_names_the_chunk_table_already_recovers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(
+        &root,
+        "base",
+        "Test.wad.client/ASSETS/Custom/One.tex",
+        b"tex",
+    );
+    // `one` differs from the stored path only in case; `two` is stored by no
+    // chunk and must survive.
+    let project = game_table_project(&root, "assets/custom/one.tex\nASSETS/Custom/Two.tex\n");
+
+    let (mut modpkg, report) = pack(project, &root);
+
+    let tables = modpkg.load_hashtables().unwrap();
+    assert_eq!(
+        tables[0].1.names().collect::<Vec<_>>(),
+        ["ASSETS/Custom/Two.tex"]
+    );
+    // A silent trim and an empty table look identical from outside, and only
+    // one of them is correct - the count is part of the pack's report.
+    assert_eq!(report.trimmed_game_names(), 1);
+}
+
+/// `game` only: nothing in a package deduces a `binentries` or `binhashes`
+/// name, so trimming any other category would simply delete it.
+#[test]
+fn the_trim_leaves_every_other_category_alone() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(
+        &root,
+        "base",
+        "Test.wad.client/ASSETS/Custom/One.tex",
+        b"tex",
+    );
+    fs::create_dir_all(root.join("hashes")).unwrap();
+    fs::write(
+        root.join("hashes/binhashes.hashes.txt"),
+        "ASSETS/Custom/One.tex\n",
+    )
+    .unwrap();
+
+    let project = ModProject {
+        hashtables: vec![crate::ModProjectHashtable {
+            path: "hashes/binhashes.hashes.txt".to_string(),
+            category: ltk_hashtable::Category::BinHashes,
+            algorithm: ltk_hashtable::Algorithm::Fnv1a32,
+            bits: 32,
+        }],
+        ..test_mod_project(vec![ModProjectLayer::base()])
+    };
+
+    let (mut modpkg, report) = pack(project, &root);
+
+    let tables = modpkg.load_hashtables().unwrap();
+    assert_eq!(
+        tables[0].1.names().collect::<Vec<_>>(),
+        ["ASSETS/Custom/One.tex"]
+    );
+    assert_eq!(report.trimmed_game_names(), 0);
+}
+
+/// One file, two shapes: two manifest entries over one table file survive the
+/// modpkg hop as two declarations of one chunk - and the shared chunk is not
+/// trimmed, because a name only one shape finds redundant must survive for
+/// the others.
+#[test]
+fn two_declarations_over_one_file_both_survive_the_modpkg_hop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(
+        &root,
+        "base",
+        "Test.wad.client/ASSETS/Custom/One.tex",
+        b"tex",
+    );
+    // `One.tex` is recoverable from the stored chunk path, so a lone `game`
+    // declaration would trim it - the second shape must prevent that.
+    fs::create_dir_all(root.join("hashes")).unwrap();
+    fs::write(
+        root.join("hashes/game.hashes.txt"),
+        "ASSETS/Custom/One.tex\n",
+    )
+    .unwrap();
+
+    let entry = |bits| crate::ModProjectHashtable {
+        path: "hashes/game.hashes.txt".to_string(),
+        category: ltk_hashtable::Category::Game,
+        algorithm: ltk_hashtable::Algorithm::Xxh64,
+        bits,
+    };
+    let project = ModProject {
+        hashtables: vec![entry(64), entry(32)],
+        ..test_mod_project(vec![ModProjectLayer::base()])
+    };
+
+    let (mut modpkg, report) = pack(project, &root);
+
+    let tables = modpkg.load_hashtables().unwrap();
+    assert_eq!(tables.len(), 2, "both declarations survive the hop");
+    for (_, table) in &tables {
+        assert_eq!(table.names().collect::<Vec<_>>(), ["ASSETS/Custom/One.tex"]);
+    }
+    assert_eq!(
+        report.trimmed_game_names(),
+        0,
+        "a chunk two shapes declare is never trimmed"
+    );
+}
+
+/// Tables land flat under `_meta_/hashes/` by file name, so two different
+/// table files can collide on one archive name. Refused rather than
+/// renamed: a silently renamed table would ship under a name nobody chose.
+#[test]
+fn colliding_table_file_names_fail_the_pack() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(&root, "base", "Test.wad.client/data.bin", b"content");
+    fs::create_dir_all(root.join("hashes")).unwrap();
+    fs::create_dir_all(root.join("backup")).unwrap();
+    fs::write(
+        root.join("hashes/game.hashes.txt"),
+        "ASSETS/Custom/One.tex\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("backup/game.hashes.txt"),
+        "ASSETS/Custom/Two.tex\n",
+    )
+    .unwrap();
+
+    let entry = |path: &str| crate::ModProjectHashtable {
+        path: path.to_string(),
+        category: ltk_hashtable::Category::Game,
+        algorithm: ltk_hashtable::Algorithm::Xxh64,
+        bits: 64,
+    };
+    let project = ModProject {
+        hashtables: vec![
+            entry("hashes/game.hashes.txt"),
+            entry("backup/game.hashes.txt"),
+        ],
+        ..test_mod_project(vec![ModProjectLayer::base()])
+    };
+
+    let err = try_pack(project, &root).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            PackError::Format(ModpkgPackError::DuplicateHashtableName(ref e))
+                if e.destination() == "_meta_/hashes/game.hashes.txt"
+                    && e.first() == "hashes/game.hashes.txt"
+                    && e.second() == "backup/game.hashes.txt"
+        ),
+        "Expected DuplicateHashtableName, got: {err}"
+    );
+}
+
+/// Two case-variant declared paths land on one chunk (chunk paths are
+/// case-insensitive), but whether they are one file is the filesystem's
+/// secret - on a case-sensitive one they can be two files with different
+/// bytes. The pack refuses the ambiguous pair on every platform rather
+/// than pack differently on different filesystems.
+#[test]
+fn case_variant_table_declarations_fail_the_pack() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(&root, "base", "Test.wad.client/data.bin", b"content");
+    fs::create_dir_all(root.join("hashes")).unwrap();
+    fs::write(
+        root.join("hashes/Game.hashes.txt"),
+        "ASSETS/Custom/One.tex\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("hashes/game.hashes.txt"),
+        "ASSETS/Custom/Two.tex\n",
+    )
+    .unwrap();
+
+    let entry = |path: &str| crate::ModProjectHashtable {
+        path: path.to_string(),
+        category: ltk_hashtable::Category::Game,
+        algorithm: ltk_hashtable::Algorithm::Xxh64,
+        bits: 64,
+    };
+    let project = ModProject {
+        hashtables: vec![
+            entry("hashes/Game.hashes.txt"),
+            entry("hashes/game.hashes.txt"),
+        ],
+        ..test_mod_project(vec![ModProjectLayer::base()])
+    };
+
+    let err = try_pack(project, &root).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            PackError::Format(ModpkgPackError::DuplicateHashtableName(ref e))
+                if e.destination().eq_ignore_ascii_case("_meta_/hashes/game.hashes.txt")
+                    && e.first() == "hashes/Game.hashes.txt"
+                    && e.second() == "hashes/game.hashes.txt"
+        ),
+        "Expected DuplicateHashtableName, got: {err}"
+    );
+}
+
+/// The escape hatch, packing side: an extraction that cannot name a chunk
+/// writes it at the WAD root under the hex of its path hash, so a WAD-root
+/// file whose stem is exactly that width is the raw hash, not a path - the
+/// chunk must come back under the hash the game knows it by.
+#[test]
+fn a_wad_root_hex_named_file_packs_as_a_raw_path_hash() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(
+        &root,
+        "base",
+        "Test.wad.client/abcdef1234567890.dds",
+        b"tex",
+    );
+
+    let (modpkg, _) = pack(test_mod_project(vec![ModProjectLayer::base()]), &root);
+
+    let key = ChunkKey::new(
+        ltk_modpkg::PathHash::new(0xabcdef1234567890),
+        LayerHash::from_name("base"),
+    );
+    assert!(
+        modpkg.chunks().contains_key(&key),
+        "the chunk must be keyed by the raw hash the hex name encodes"
+    );
+}
+
+/// Only the WAD root means raw hash: a hex-looking name inside a directory is
+/// a real path, and so is a WAD-root name of any other shape.
+#[test]
+fn a_nested_hex_named_file_stays_a_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(
+        &root,
+        "base",
+        "Test.wad.client/data/abcdef1234567890.dds",
+        b"tex",
+    );
+
+    let (modpkg, _) = pack(test_mod_project(vec![ModProjectLayer::base()]), &root);
+
+    let key = ChunkKey::new(
+        ChunkPath::new("data/abcdef1234567890.dds").hash(),
+        LayerHash::from_name("base"),
+    );
+    assert!(modpkg.chunks().contains_key(&key));
+}
+
+/// A table with an unknown category survives all three hops: unknown means
+/// "round-trip verbatim", never "disposable", so project -> modpkg ->
+/// project -> fantome keeps its spelling and its names.
+#[cfg(feature = "fantome")]
+#[test]
+fn an_unknown_category_survives_all_three_hops() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8_tempdir(&tmp);
+    create_content_file(&root, "base", "Test.wad.client/data.bin", b"content");
+    fs::create_dir_all(root.join("hashes")).unwrap();
+    fs::write(
+        root.join("hashes/wadnames.hashes.txt"),
+        "some/opaque.name\n",
+    )
+    .unwrap();
+
+    let project = ModProject {
+        hashtables: vec![crate::ModProjectHashtable {
+            path: "hashes/wadnames.hashes.txt".to_string(),
+            category: ltk_hashtable::Category::Unknown("wadnames".to_string()),
+            algorithm: ltk_hashtable::Algorithm::Unknown("crc32".to_string()),
+            bits: 32,
+        }],
+        ..test_mod_project(vec![ModProjectLayer::base()])
+    };
+
+    let mut buffer = Cursor::new(Vec::new());
+    ProjectPacker::new(project, root.to_owned())
+        .pack(ModpkgFormat::new(&mut buffer))
+        .unwrap();
+
+    let output = utf8_tempdir(&tmp).join("imported");
+    let imported = import(buffer.into_inner(), &output);
+    assert_eq!(
+        imported.hashtables[0].category,
+        ltk_hashtable::Category::Unknown("wadnames".to_string())
+    );
+
+    let mut fantome_buffer = Cursor::new(Vec::new());
+    ProjectPacker::new(imported, output)
+        .pack(crate::fantome::FantomeFormat::new(&mut fantome_buffer))
+        .unwrap();
+
+    fantome_buffer.set_position(0);
+    let mut reader = ltk_fantome::FantomeReader::new(fantome_buffer).unwrap();
+    let tables = reader.read_hashtables().unwrap();
+    assert_eq!(tables.len(), 1);
+    let (entry, table) = &tables[0];
+    assert_eq!(
+        *entry.category(),
+        ltk_hashtable::Category::Unknown("wadnames".to_string())
+    );
+    assert_eq!(
+        *entry.algorithm(),
+        ltk_hashtable::Algorithm::Unknown("crc32".to_string())
+    );
+    assert_eq!(table.names().collect::<Vec<_>>(), ["some/opaque.name"]);
+}
+
+/// An entry whose declared width no key can have is dropped from the imported
+/// manifest rather than carried: `PackPlan::hashtables()` refuses an
+/// impossible width, so carrying it would import a project that cannot pack.
+#[test]
+fn an_impossible_width_is_dropped_from_the_imported_manifest() {
+    let metadata = ModpkgMetadata {
+        hashtables: vec![ltk_modpkg::ModpkgHashtable {
+            path: "_meta_/hashes/game.hashes.txt".to_string(),
+            category: ltk_hashtable::Category::Game,
+            algorithm: ltk_hashtable::Algorithm::Xxh64,
+            bits: 0,
+        }],
+        ..ModpkgMetadata::default()
+    };
+
+    assert!(ModProject::from(&metadata).hashtables.is_empty());
+}
+
 // -- importing a package as a project ---------------------------------------
 
 /// Pack a project with a base-layer and a second-layer file, plus a readme, and

--- a/crates/ltk_mod_project/src/pack/mod.rs
+++ b/crates/ltk_mod_project/src/pack/mod.rs
@@ -19,7 +19,7 @@
 //! `Format` variant carries the backend's own error.
 //!
 //! ```no_run
-//! use ltk_mod_project::{PackFormat, PackPlan, PackReporter, ProjectPacker};
+//! use ltk_mod_project::{PackFormat, PackFormatReport, PackPlan, PackReporter, ProjectPacker};
 //!
 //! /// A toy format: counts the files a pack would write.
 //! struct EntryCount<'a>(&'a mut usize);
@@ -27,14 +27,18 @@
 //! impl PackFormat for EntryCount<'_> {
 //!     type Error = std::convert::Infallible;
 //!
-//!     fn pack(self, plan: &PackPlan<'_>, progress: &mut PackReporter<'_>) -> Result<(), Self::Error> {
+//!     fn pack(
+//!         self,
+//!         plan: &PackPlan<'_>,
+//!         progress: &mut PackReporter<'_>,
+//!     ) -> Result<PackFormatReport, Self::Error> {
 //!         for layer in plan.layers() {
 //!             for file in layer.files() {
 //!                 progress.report_file(file.rel_path());
 //!                 *self.0 += 1;
 //!             }
 //!         }
-//!         Ok(())
+//!         Ok(PackFormatReport::default())
 //!     }
 //! }
 //!
@@ -57,7 +61,7 @@ mod tests;
 
 pub use options::{IgnoreMode, PackOptions};
 pub use packer::{PackError, PackReport, ProjectPacker};
-pub use plan::{PackPlan, PlannedFile, PlannedLayer, PlannedLicense};
+pub use plan::{PackPlan, PlannedFile, PlannedHashtable, PlannedLayer, PlannedLicense};
 pub use progress::{PackProgress, PackReporter, PackStage};
 
 /// An archive format [`ProjectPacker`] can pack a project into.
@@ -85,5 +89,29 @@ pub trait PackFormat {
     /// Call [`PackReporter::report_file`] before writing each content file, so
     /// a caller watching a long pack sees where it has got to. A format that
     /// stores only part of the plan reports only what it writes.
-    fn pack(self, plan: &PackPlan<'_>, progress: &mut PackReporter<'_>) -> Result<(), Self::Error>;
+    ///
+    /// The returned [`PackFormatReport`] carries the facts only the format
+    /// knows; the driver folds them into the [`PackReport`] it returns. A
+    /// format with nothing to say returns `PackFormatReport::default()`.
+    ///
+    /// [`PackReport`]: crate::PackReport
+    fn pack(
+        self,
+        plan: &PackPlan<'_>,
+        progress: &mut PackReporter<'_>,
+    ) -> Result<PackFormatReport, Self::Error>;
+}
+
+/// What a format did beyond writing the plan - facts the driver folds into
+/// the [`PackReport`](crate::PackReport) it returns.
+///
+/// Distinct from [`PackReporter`], which streams progress while the pack
+/// runs: this is the result, read when it is done.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PackFormatReport {
+    /// `game` hashtable names the format omitted because the package's own
+    /// chunk table already recovers them. Only the modpkg format trims;
+    /// every other format reports 0.
+    pub trimmed_game_names: usize,
 }

--- a/crates/ltk_mod_project/src/pack/packer.rs
+++ b/crates/ltk_mod_project/src/pack/packer.rs
@@ -4,8 +4,9 @@ use std::fs;
 use std::io;
 
 use camino::{Utf8Path, Utf8PathBuf};
+use ltk_hashtable::{Collision, Hashtable, HashtableReadError, HashtableSet};
 
-use super::plan::{PackPlan, PlannedFile, PlannedLayer, PlannedLicense};
+use super::plan::{PackPlan, PlannedFile, PlannedHashtable, PlannedLayer, PlannedLicense};
 use super::progress::{PackProgress, PackReporter};
 use super::{IgnoreMode, PackFormat, PackOptions};
 use crate::{
@@ -52,6 +53,36 @@ pub enum PackError<E> {
     #[error(transparent)]
     Walk(#[from] ContentWalkError),
 
+    /// A declared hashtable's key width is not one a key can have; the
+    /// standard requires 1 to 64 bits.
+    #[error("Hashtable {path} declares a key width of {bits} bits; a key holds 1 to 64")]
+    HashtableWidth {
+        /// The table's declared path, relative to the project root.
+        path: Utf8PathBuf,
+        /// The width the manifest declares.
+        bits: u8,
+    },
+
+    /// A declared hashtable file is missing, or does not fit the table
+    /// grammar.
+    #[error("Failed to read the hashtable at {path}")]
+    Hashtable {
+        /// The table's path on disk.
+        path: Utf8PathBuf,
+        #[source]
+        source: HashtableReadError,
+    },
+
+    /// Two different names in one category truncate to one key, so one of
+    /// them could never be resolved again. Only the author can fix it - by
+    /// renaming a file - so the pack fails rather than shipping a broken
+    /// table.
+    #[error(
+        "The {} tables collide: {:?} and {:?} share the key {}",
+        .0.category, .0.first, .0.second, .0.key
+    )]
+    HashtableCollision(Box<Collision>),
+
     /// An [`IgnoreMode::Explicit`] filter was built for a different project
     /// root than the packer was given, so it would relate every scanned path
     /// to the wrong content dir and quietly filter wrong.
@@ -80,6 +111,7 @@ impl<E> PackError<E> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct PackReport {
     ignored: Vec<Utf8PathBuf>,
+    trimmed_game_names: usize,
 }
 
 impl PackReport {
@@ -93,6 +125,16 @@ impl PackReport {
     /// `ignored_files().len()`, for reporting.
     pub fn ignored_count(&self) -> usize {
         self.ignored.len()
+    }
+
+    /// `game` hashtable names the format omitted because the package's own
+    /// chunk table already recovers them.
+    ///
+    /// A silent trim and an empty table look identical from outside, and
+    /// only one of them is correct - report this to the user when it is not
+    /// zero. Only the modpkg format trims; every other format reports 0.
+    pub fn trimmed_game_names(&self) -> usize {
+        self.trimmed_game_names
     }
 }
 
@@ -250,15 +292,19 @@ impl ProjectPacker {
             self.find_readme(),
             self.find_license(),
             self.find_thumbnail(),
+            self.resolve_hashtables()?,
         );
 
-        format
+        let format_report = format
             .pack(&plan, &mut progress)
             .map_err(PackError::Format)?;
 
         progress.report_complete();
 
-        Ok(PackReport { ignored })
+        Ok(PackReport {
+            ignored,
+            trimmed_game_names: format_report.trimmed_game_names,
+        })
     }
 
     /// The layers a pack covers: the base layer first (synthesized when the
@@ -311,6 +357,45 @@ impl ProjectPacker {
             .and_then(canonical_license_file_name)
             .unwrap_or("LICENSE");
         Some(PlannedLicense::new(path, canonical))
+    }
+
+    /// Read and validate the hashtables the config declares, in manifest
+    /// order.
+    ///
+    /// Every declared table is read here, whatever format the pack targets:
+    /// collisions are judged over the merged category, which is what a reader
+    /// of the packed archive will see, and a table the driver cannot read is
+    /// a table no archive should ship.
+    fn resolve_hashtables<E>(&self) -> Result<Vec<PlannedHashtable>, PackError<E>> {
+        let mut planned = Vec::with_capacity(self.project.hashtables.len());
+        for manifest in &self.project.hashtables {
+            let Some(entry) = manifest.to_entry() else {
+                return Err(PackError::HashtableWidth {
+                    path: manifest.path.clone().into(),
+                    bits: manifest.bits,
+                });
+            };
+            let source = self.project_root.join(&manifest.path);
+            let table = fs::File::open(source.as_std_path())
+                .map_err(HashtableReadError::from)
+                .and_then(|file| Hashtable::from_reader(io::BufReader::new(file)))
+                .map_err(|error| PackError::Hashtable {
+                    path: source.clone(),
+                    source: error,
+                })?;
+            planned.push(PlannedHashtable::new(source, entry, table));
+        }
+
+        let merged = HashtableSet::build(
+            planned
+                .iter()
+                .map(|table| (table.entry().clone(), table.table().clone())),
+        );
+        if let Some(collision) = merged.collisions().first() {
+            return Err(PackError::HashtableCollision(Box::new(collision.clone())));
+        }
+
+        Ok(planned)
     }
 
     fn find_thumbnail(&self) -> Option<Utf8PathBuf> {

--- a/crates/ltk_mod_project/src/pack/plan.rs
+++ b/crates/ltk_mod_project/src/pack/plan.rs
@@ -1,6 +1,7 @@
 //! [`PackPlan`]: the driver's resolved view of what a pack will write.
 
 use camino::{Utf8Path, Utf8PathBuf};
+use ltk_hashtable::{Hashtable, HashtableEntry};
 
 use crate::{ModProject, ModProjectLayer};
 
@@ -17,6 +18,7 @@ pub struct PackPlan<'a> {
     readme: Option<Utf8PathBuf>,
     license: Option<PlannedLicense>,
     thumbnail: Option<Utf8PathBuf>,
+    hashtables: Vec<PlannedHashtable>,
 }
 
 impl<'a> PackPlan<'a> {
@@ -27,6 +29,7 @@ impl<'a> PackPlan<'a> {
         readme: Option<Utf8PathBuf>,
         license: Option<PlannedLicense>,
         thumbnail: Option<Utf8PathBuf>,
+        hashtables: Vec<PlannedHashtable>,
     ) -> Self {
         Self {
             project,
@@ -35,6 +38,7 @@ impl<'a> PackPlan<'a> {
             readme,
             license,
             thumbnail,
+            hashtables,
         }
     }
 
@@ -78,6 +82,17 @@ impl<'a> PackPlan<'a> {
     /// `thumbnail.webp` at the project root when none is configured.
     pub fn thumbnail(&self) -> Option<&Utf8Path> {
         self.thumbnail.as_deref()
+    }
+
+    /// The hashtables the project declares, read and validated, in manifest
+    /// order.
+    ///
+    /// The driver has already read every table and failed the pack on a
+    /// missing file, an impossible key width or a key collision, so a format
+    /// only encodes what it is handed. A format that stores no tables skips
+    /// them, as with any other part of the plan.
+    pub fn hashtables(&self) -> &[PlannedHashtable] {
+        &self.hashtables
     }
 }
 
@@ -138,6 +153,46 @@ impl PlannedFile {
     /// spelling, if it sits inside one.
     pub fn wad(&self) -> Option<&str> {
         self.wad.as_deref()
+    }
+}
+
+/// One declared hashtable, resolved for packing: its manifest entry and the
+/// table the file holds.
+///
+/// The entry's [`path`](HashtableEntry::path) is project-relative, as the
+/// manifest declares it; where a table lands inside an archive is each
+/// format's decision. The table travels parsed because the driver has to read
+/// it anyway to detect collisions, so a format writes names rather than
+/// copying a file it would have to trust.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedHashtable {
+    source: Utf8PathBuf,
+    entry: HashtableEntry,
+    table: Hashtable,
+}
+
+impl PlannedHashtable {
+    pub(crate) fn new(source: Utf8PathBuf, entry: HashtableEntry, table: Hashtable) -> Self {
+        Self {
+            source,
+            entry,
+            table,
+        }
+    }
+
+    /// Absolute path of the table file on disk.
+    pub fn source(&self) -> &Utf8Path {
+        &self.source
+    }
+
+    /// The manifest entry, its path relative to the project root.
+    pub fn entry(&self) -> &HashtableEntry {
+        &self.entry
+    }
+
+    /// The table's names, as the file holds them.
+    pub fn table(&self) -> &Hashtable {
+        &self.table
     }
 }
 

--- a/crates/ltk_mod_project/src/pack/tests.rs
+++ b/crates/ltk_mod_project/src/pack/tests.rs
@@ -34,7 +34,7 @@ impl PackFormat for Capture<'_> {
         self,
         plan: &PackPlan<'_>,
         _progress: &mut PackReporter<'_>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<crate::PackFormatReport, Self::Error> {
         self.0.layers = plan
             .layers()
             .iter()
@@ -60,7 +60,7 @@ impl PackFormat for Capture<'_> {
             .license()
             .map(|license| (license.source().to_owned(), license.canonical_name()));
         self.0.thumbnail = plan.thumbnail().map(Utf8Path::to_owned);
-        Ok(())
+        Ok(crate::PackFormatReport::default())
     }
 }
 
@@ -375,7 +375,7 @@ fn format_errors_pass_through_transparently() {
             self,
             _plan: &PackPlan<'_>,
             _progress: &mut PackReporter<'_>,
-        ) -> Result<(), Self::Error> {
+        ) -> Result<crate::PackFormatReport, Self::Error> {
             Err(std::io::Error::other("boom"))
         }
     }
@@ -677,13 +677,17 @@ struct ReportEverything;
 impl PackFormat for ReportEverything {
     type Error = Infallible;
 
-    fn pack(self, plan: &PackPlan<'_>, progress: &mut PackReporter<'_>) -> Result<(), Self::Error> {
+    fn pack(
+        self,
+        plan: &PackPlan<'_>,
+        progress: &mut PackReporter<'_>,
+    ) -> Result<crate::PackFormatReport, Self::Error> {
         for layer in plan.layers() {
             for file in layer.files() {
                 progress.report_file(file.rel_path());
             }
         }
-        Ok(())
+        Ok(crate::PackFormatReport::default())
     }
 }
 
@@ -742,8 +746,8 @@ fn pack_completes_even_when_the_format_reports_nothing() {
             self,
             _plan: &PackPlan<'_>,
             _progress: &mut PackReporter<'_>,
-        ) -> Result<(), Self::Error> {
-            Ok(())
+        ) -> Result<crate::PackFormatReport, Self::Error> {
+            Ok(crate::PackFormatReport::default())
         }
     }
 

--- a/crates/ltk_mod_project/src/preserve.rs
+++ b/crates/ltk_mod_project/src/preserve.rs
@@ -1,0 +1,237 @@
+//! Preserving a mod's names: harvest what is still readable and rewrite it
+//! into the mod's own archive, before a repair makes it unreadable.
+//!
+//! [`preserve_archive_names`] is deliberately import-shaped: it reads the
+//! archive at `source` and writes the preserved archive at `dest`, so the way
+//! a mod enters a library *is* the preserve. A repair that only ever runs on
+//! library mods then cannot run before the harvest - the ordering the whole
+//! feature depends on holds by construction rather than by convention.
+
+use std::fs::{self, File};
+use std::io::{BufReader, Cursor};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use ltk_fantome::{
+    add_hashtables, classify_entry, FantomeEntry, FantomeExtractError, FantomeReader,
+    FantomeRewriteError, RewriteOutcome,
+};
+use ltk_hashtable::{Category, Hashtable, Key};
+use ltk_wad::{is_hex_chunk_path, NameRecovery, NoResolver, PathResolver, Wad, WadError, WadHash};
+
+#[cfg(test)]
+mod tests;
+
+/// A preserve's account of itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HarvestReport {
+    /// Whether the mod was rewritten, and how many names it gained.
+    pub outcome: PreserveOutcome,
+    /// How many chunks have no recoverable name: hex-named, and named by
+    /// nothing the harvest can read. Counted, never guessed at.
+    pub unharvestable: usize,
+}
+
+/// What a preserve did to the archive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreserveOutcome {
+    /// Every harvested name was already declared or excluded; the archive at
+    /// `dest` is a plain copy of the source.
+    Unchanged,
+    /// The archive at `dest` declares the harvested names.
+    Rewritten {
+        /// How many names the archive gained.
+        names_added: usize,
+    },
+}
+
+/// Failure to preserve an archive's names.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PreserveError {
+    /// A file could not be read or written.
+    #[error("Failed to access {path}")]
+    Io {
+        /// The file that failed.
+        path: Utf8PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The source archive could not be read.
+    #[error(transparent)]
+    Archive(#[from] FantomeExtractError),
+
+    /// The rewritten archive could not be produced.
+    #[error(transparent)]
+    Rewrite(#[from] FantomeRewriteError),
+
+    /// A packed WAD inside the archive could not be read for names.
+    #[error("Failed to read the packed WAD {wad}")]
+    Wad {
+        /// The WAD's name, as the archive spells it.
+        wad: String,
+        #[source]
+        source: WadError,
+    },
+}
+
+impl PreserveError {
+    fn io(path: impl Into<Utf8PathBuf>, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.into(),
+            source,
+        }
+    }
+}
+
+/// Harvest the names of the `.fantome` archive at `source` and write the
+/// archive, names embedded, to `dest`.
+///
+/// The harvest reads the two places a mod's names still survive - the chunk
+/// paths of its WAD directories, and the strings inside the bins of its
+/// packed WADs - and merges what is genuinely new into the archive's embedded
+/// hashtables. `exclusions` names what a reader can recover without the mod's
+/// help, in practice the community hashtables; a name it knows is not
+/// embedded. Passing `None` embeds every harvested name, which costs size,
+/// never correctness.
+///
+/// When nothing is new the archive at `dest` is a plain copy of the source
+/// (or, when `dest` *is* `source`, nothing is written at all) - a covered mod
+/// is never rewritten, and running twice is a no-op. When something is new
+/// the rewrite lands as a temporary file beside `dest` and is renamed over it
+/// only after writing finishes cleanly, so an interrupted preserve never
+/// leaves a half-written archive where a mod should be. The source is never
+/// modified.
+///
+/// # Errors
+///
+/// Returns an error if the source cannot be read, a packed WAD inside it
+/// cannot be mounted, or the destination cannot be written. `dest` is left as
+/// it was on any error.
+pub fn preserve_archive_names(
+    source: &Utf8Path,
+    dest: &Utf8Path,
+    exclusions: Option<&dyn PathResolver>,
+) -> Result<HarvestReport, PreserveError> {
+    let file = File::open(source.as_std_path()).map_err(|e| PreserveError::io(source, e))?;
+    let mut reader = FantomeReader::new(BufReader::new(file))?;
+
+    let exclusions = exclusions.unwrap_or(&NoResolver);
+    let (table, unharvestable) = harvest(&mut reader, exclusions)?;
+
+    let parent = match dest.parent() {
+        Some(parent) if !parent.as_str().is_empty() => parent,
+        _ => Utf8Path::new("."),
+    };
+    fs::create_dir_all(parent.as_std_path()).map_err(|e| PreserveError::io(parent, e))?;
+    let mut temp = tempfile::NamedTempFile::new_in(parent.as_std_path())
+        .map_err(|e| PreserveError::io(parent, e))?;
+
+    let outcome = add_hashtables(&mut reader, temp.as_file_mut(), &[(Category::Game, table)])?;
+    drop(reader);
+
+    let outcome = match outcome {
+        RewriteOutcome::Unchanged => {
+            if source == dest {
+                drop(temp);
+            } else {
+                // The plain copy still lands through the temp file and the
+                // rename, so an interrupted preserve can no more truncate a
+                // covered mod than a rewritten one.
+                let mut original =
+                    File::open(source.as_std_path()).map_err(|e| PreserveError::io(source, e))?;
+                std::io::copy(&mut original, temp.as_file_mut())
+                    .map_err(|e| PreserveError::io(dest, e))?;
+                temp.persist(dest.as_std_path())
+                    .map_err(|e| PreserveError::io(dest, e.error))?;
+            }
+            PreserveOutcome::Unchanged
+        }
+        RewriteOutcome::Rewritten { names_added } => {
+            temp.persist(dest.as_std_path())
+                .map_err(|e| PreserveError::io(dest, e.error))?;
+            PreserveOutcome::Rewritten { names_added }
+        }
+    };
+
+    Ok(HarvestReport {
+        outcome,
+        unharvestable,
+    })
+}
+
+/// The WAD-space hash of `name`, computed by the crate that owns hashing so
+/// the exclusion check and the embedded table cannot disagree about a key.
+fn wad_hash(name: &str) -> WadHash {
+    let (algorithm, width) = Category::Game
+        .default_shape()
+        .expect("game is a known category with a computable shape");
+    let key = Key::of(name, &algorithm, width).expect("xxh64 keys are always computable");
+    WadHash(key.value())
+}
+
+/// Read the names still recoverable from the archive: chunk paths on disk,
+/// then names the bins of each packed WAD hold.
+fn harvest<R: std::io::Read + std::io::Seek>(
+    reader: &mut FantomeReader<R>,
+    exclusions: &dyn PathResolver,
+) -> Result<(Hashtable, usize), PreserveError> {
+    let mut table = Hashtable::default();
+    let mut unharvestable = 0;
+
+    let mut packed_wads = Vec::new();
+    for entry_name in reader.entry_names() {
+        match classify_entry(entry_name) {
+            Some(FantomeEntry::WadFile(relative_path)) => {
+                let Some((_wad_dir, chunk_path)) = relative_path.split_once('/') else {
+                    continue;
+                };
+                if is_hex_chunk_path(Utf8Path::new(chunk_path)) {
+                    unharvestable += 1;
+                    continue;
+                }
+                if exclusions.is_known(wad_hash(chunk_path)) {
+                    continue;
+                }
+                // A name outside the table grammar cannot be embedded;
+                // nothing else can carry it either, so it counts as lost.
+                if table.push(chunk_path).is_err() {
+                    unharvestable += 1;
+                }
+            }
+            Some(FantomeEntry::PackedWad(name)) => packed_wads.push(name.to_owned()),
+            _ => {}
+        }
+    }
+
+    for wad_name in packed_wads {
+        let Some(bytes) = reader.read_packed_wad(&wad_name)? else {
+            continue;
+        };
+        let mut wad = Wad::mount(Cursor::new(bytes)).map_err(|source| PreserveError::Wad {
+            wad: wad_name.clone(),
+            source,
+        })?;
+        let recovered = NameRecovery::new()
+            .run(&mut wad, exclusions)
+            .map_err(|source| PreserveError::Wad {
+                wad: wad_name.clone(),
+                source,
+            })?;
+        for chunk in wad.chunks() {
+            if exclusions.is_known(chunk.path_hash) {
+                continue;
+            }
+            match recovered.get(chunk.path_hash) {
+                Some(path) => {
+                    if table.push(path).is_err() {
+                        unharvestable += 1;
+                    }
+                }
+                None => unharvestable += 1,
+            }
+        }
+    }
+
+    Ok((table, unharvestable))
+}

--- a/crates/ltk_mod_project/src/preserve/tests.rs
+++ b/crates/ltk_mod_project/src/preserve/tests.rs
@@ -1,0 +1,230 @@
+use std::fs::File;
+use std::io::Cursor;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use ltk_fantome::{FantomeInfo, FantomeReader, FantomeWriter};
+use ltk_hashtable::Category;
+
+use super::{preserve_archive_names, PreserveOutcome};
+
+fn write_source(dir: &Utf8Path, entries: &[(&str, &str, &[u8])]) -> Utf8PathBuf {
+    let path = dir.join("mod.fantome");
+    let mut writer = FantomeWriter::new(File::create(path.as_std_path()).unwrap());
+    writer
+        .write_info(&FantomeInfo {
+            name: "Mod".to_owned(),
+            ..Default::default()
+        })
+        .unwrap();
+    for (wad, rel, content) in entries {
+        writer.write_wad_entry(wad, rel, &mut &content[..]).unwrap();
+    }
+    writer.finish().unwrap();
+    path
+}
+
+fn temp_dir() -> (tempfile::TempDir, Utf8PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = Utf8Path::from_path(dir.path()).unwrap().to_owned();
+    (dir, path)
+}
+
+#[test]
+fn chunk_paths_on_disk_are_harvested_and_a_hex_name_is_not_guessed_at() {
+    let (_guard, dir) = temp_dir();
+    let source = write_source(
+        &dir,
+        &[
+            ("Aatrox.wad.client", "ASSETS/Custom/Trail.tex", b"a"),
+            ("Aatrox.wad.client", "0123456789abcdef.tex", b"b"),
+        ],
+    );
+    let dest = dir.join("library.fantome");
+
+    let report = preserve_archive_names(&source, &dest, None).unwrap();
+
+    assert_eq!(
+        report.outcome,
+        PreserveOutcome::Rewritten { names_added: 1 }
+    );
+    assert_eq!(report.unharvestable, 1);
+
+    let mut reader = FantomeReader::new(File::open(dest.as_std_path()).unwrap()).unwrap();
+    let tables = reader.read_hashtables().unwrap();
+    assert_eq!(tables.len(), 1);
+    assert_eq!(*tables[0].0.category(), Category::Game);
+    assert_eq!(
+        tables[0].1.names().collect::<Vec<_>>(),
+        ["ASSETS/Custom/Trail.tex"]
+    );
+    // The source the user gave is untouched.
+    let mut source_reader = FantomeReader::new(File::open(source.as_std_path()).unwrap()).unwrap();
+    assert!(source_reader.read_hashtables().unwrap().is_empty());
+    let _ = Cursor::new(());
+}
+
+/// A string as a bin writes it: a little-endian u16 length and the bytes.
+fn bin_string(out: &mut Vec<u8>, text: &str) {
+    out.extend_from_slice(&(text.len() as u16).to_le_bytes());
+    out.extend_from_slice(text.as_bytes());
+}
+
+/// Enough of a bin to carry the magic and a few strings.
+fn bin_with(paths: &[&str]) -> Vec<u8> {
+    let mut out = b"PROP".to_vec();
+    out.extend_from_slice(&2u32.to_le_bytes());
+    out.extend_from_slice(&(paths.len() as u32).to_le_bytes());
+    for path in paths {
+        bin_string(&mut out, path);
+    }
+    out
+}
+
+#[test]
+fn names_in_a_packed_wads_bins_are_harvested() {
+    use std::io::Write;
+
+    use ltk_wad::{WadBuilder, WadChunkBuilder};
+
+    let recovered_path = "assets/custom/recovered.tex";
+    let bin = bin_with(&[recovered_path]);
+
+    let mut wad_bytes = Cursor::new(Vec::new());
+    WadBuilder::default()
+        .with_chunk(WadChunkBuilder::default().with_path(recovered_path))
+        .with_chunk(WadChunkBuilder::default().with_path("data/anonymous.bin"))
+        .build_to_writer(&mut wad_bytes, |hash, cursor| {
+            if hash == ltk_wad::WadHash::from(recovered_path) {
+                cursor.write_all(b"texture payload")?;
+            } else {
+                cursor.write_all(&bin)?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    let (_guard, dir) = temp_dir();
+    let source = dir.join("mod.fantome");
+    let mut zip = zip::ZipWriter::new(File::create(source.as_std_path()).unwrap());
+    let options = zip::write::SimpleFileOptions::default();
+    zip.start_file("META/info.json", options).unwrap();
+    serde_json::to_writer(
+        &mut zip,
+        &FantomeInfo {
+            name: "Packed".to_owned(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    zip.start_file("WAD/Aatrox.wad.client", options).unwrap();
+    zip.write_all(&wad_bytes.into_inner()).unwrap();
+    zip.finish().unwrap();
+    let dest = dir.join("library.fantome");
+
+    let report = preserve_archive_names(&source, &dest, None).unwrap();
+
+    // The bin named the texture chunk; the bin chunk itself is named by
+    // nothing and is counted, not guessed at.
+    assert_eq!(
+        report.outcome,
+        PreserveOutcome::Rewritten { names_added: 1 }
+    );
+    assert_eq!(report.unharvestable, 1);
+
+    let mut reader = FantomeReader::new(File::open(dest.as_std_path()).unwrap()).unwrap();
+    let tables = reader.read_hashtables().unwrap();
+    assert_eq!(tables[0].1.names().collect::<Vec<_>>(), [recovered_path]);
+}
+
+#[test]
+fn the_exclusions_remove_names_a_reader_can_recover_elsewhere() {
+    use std::collections::HashMap;
+
+    use ltk_wad::WadHash;
+
+    let (_guard, dir) = temp_dir();
+    let source = write_source(
+        &dir,
+        &[
+            ("Aatrox.wad.client", "assets/known/by_community.tex", b"a"),
+            ("Aatrox.wad.client", "assets/custom/only_ours.tex", b"b"),
+        ],
+    );
+    let dest = dir.join("library.fantome");
+
+    let community: HashMap<WadHash, String> = [(
+        WadHash::from("assets/known/by_community.tex"),
+        "assets/known/by_community.tex".to_owned(),
+    )]
+    .into();
+
+    let report = preserve_archive_names(&source, &dest, Some(&community)).unwrap();
+
+    assert_eq!(
+        report.outcome,
+        PreserveOutcome::Rewritten { names_added: 1 }
+    );
+    let mut reader = FantomeReader::new(File::open(dest.as_std_path()).unwrap()).unwrap();
+    let tables = reader.read_hashtables().unwrap();
+    assert_eq!(
+        tables[0].1.names().collect::<Vec<_>>(),
+        ["assets/custom/only_ours.tex"]
+    );
+}
+
+#[test]
+fn preserving_twice_is_a_no_op() {
+    let (_guard, dir) = temp_dir();
+    let source = write_source(&dir, &[("Aatrox.wad.client", "assets/custom/a.tex", b"a")]);
+    let dest = dir.join("library.fantome");
+
+    let first = preserve_archive_names(&source, &dest, None).unwrap();
+    assert_eq!(first.outcome, PreserveOutcome::Rewritten { names_added: 1 });
+    let after_first = std::fs::read(dest.as_std_path()).unwrap();
+
+    // A second preserve of the already-preserved archive, in place.
+    let second = preserve_archive_names(&dest, &dest, None).unwrap();
+    assert_eq!(second.outcome, PreserveOutcome::Unchanged);
+    assert_eq!(std::fs::read(dest.as_std_path()).unwrap(), after_first);
+}
+
+#[test]
+fn a_preserve_that_fails_leaves_the_destination_as_it_was() {
+    let (_guard, dir) = temp_dir();
+    let source = dir.join("broken.fantome");
+    std::fs::write(source.as_std_path(), b"not a zip archive").unwrap();
+    let dest = dir.join("library.fantome");
+    std::fs::write(dest.as_std_path(), b"existing library archive").unwrap();
+
+    preserve_archive_names(&source, &dest, None).unwrap_err();
+
+    assert_eq!(
+        std::fs::read(dest.as_std_path()).unwrap(),
+        b"existing library archive"
+    );
+}
+
+#[test]
+fn a_covered_mod_is_copied_to_the_destination_unrewritten() {
+    use std::collections::HashMap;
+
+    use ltk_wad::WadHash;
+
+    let (_guard, dir) = temp_dir();
+    let source = write_source(&dir, &[("Aatrox.wad.client", "assets/known.tex", b"a")]);
+    let dest = dir.join("library.fantome");
+
+    let community: HashMap<WadHash, String> = [(
+        WadHash::from("assets/known.tex"),
+        "assets/known.tex".to_owned(),
+    )]
+    .into();
+
+    let report = preserve_archive_names(&source, &dest, Some(&community)).unwrap();
+
+    assert_eq!(report.outcome, PreserveOutcome::Unchanged);
+    assert_eq!(
+        std::fs::read(dest.as_std_path()).unwrap(),
+        std::fs::read(source.as_std_path()).unwrap()
+    );
+}

--- a/crates/ltk_mod_project/src/tests.rs
+++ b/crates/ltk_mod_project/src/tests.rs
@@ -41,6 +41,7 @@ fn create_example_project() -> ModProject {
             },
         ],
         thumbnail: None,
+        hashtables: vec![],
     }
 }
 
@@ -389,6 +390,68 @@ fn promoted_tags_keep_their_serialized_form() {
         assert_eq!(serde_json::to_value(&tag).unwrap(), serde_json::json!(name));
         assert_eq!(tag.to_string(), name);
     }
+}
+
+// -- hashtables --------------------------------------------------------------
+
+fn example_hashtables() -> Vec<ModProjectHashtable> {
+    vec![
+        ModProjectHashtable {
+            path: "hashes/game.hashes.txt".to_owned(),
+            category: ltk_hashtable::Category::Game,
+            algorithm: ltk_hashtable::Algorithm::Xxh64,
+            bits: 64,
+        },
+        // An entry from a future tool: nothing here recognizes it, and it
+        // must round trip verbatim anyway.
+        ModProjectHashtable {
+            path: "hashes/mystery.hashes.txt".to_owned(),
+            category: ltk_hashtable::Category::Unknown("mystery".to_owned()),
+            algorithm: ltk_hashtable::Algorithm::Unknown("crc-1024".to_owned()),
+            bits: 24,
+        },
+    ]
+}
+
+#[test]
+fn hashtables_round_trip_through_both_config_formats() {
+    let project = ModProject {
+        hashtables: example_hashtables(),
+        ..create_example_project()
+    };
+
+    for format in ConfigFormat::ALL {
+        let text = project.to_config_string(format).unwrap();
+        let parsed = match format {
+            ConfigFormat::Json => serde_json::from_str::<ModProject>(&text).unwrap(),
+            ConfigFormat::Toml => toml::from_str::<ModProject>(&text).unwrap(),
+        };
+        assert_eq!(parsed.hashtables, project.hashtables, "{format}");
+    }
+}
+
+/// A project without tables must serialize as it did before the field
+/// existed, so this change rewrites no one's config.
+#[test]
+fn a_project_without_hashtables_serializes_without_the_field() {
+    let value = serde_json::to_value(create_example_project()).unwrap();
+    assert!(value.get("hashtables").is_none());
+}
+
+/// The wire form is the standard's: lowercase keys, bare lowercase strings
+/// for the category and the algorithm.
+#[test]
+fn hashtable_wire_form_is_lowercase() {
+    let value = serde_json::to_value(&example_hashtables()[0]).unwrap();
+    assert_eq!(
+        value,
+        serde_json::json!({
+            "path": "hashes/game.hashes.txt",
+            "category": "game",
+            "algorithm": "xxh64",
+            "bits": 64,
+        })
+    );
 }
 
 fn temp_root(tmp: &tempfile::TempDir) -> camino::Utf8PathBuf {

--- a/crates/ltk_modpkg/Cargo.toml
+++ b/crates/ltk_modpkg/Cargo.toml
@@ -17,6 +17,7 @@ indexmap = { workspace = true }
 thiserror = "1.0.60"
 byteorder = "1.5.0"
 ltk_io_ext = "0.4.4"
+ltk_hashtable = { version = "0.1.0", path = "../ltk_hashtable" }
 serde = { version = "1.0", features = ["derive"] }
 rmp-serde = "1.3.0"
 binrw = "0.14.1"

--- a/crates/ltk_modpkg/src/builder.rs
+++ b/crates/ltk_modpkg/src/builder.rs
@@ -45,6 +45,22 @@ pub enum ModpkgBuilderError {
     #[error("invalid layer name")]
     InvalidLayerName(#[from] crate::error::InvalidSlugError),
 
+    /// A hashtable manifest named a chunk path outside `_meta_/hashes/`.
+    ///
+    /// The manifest is what pairs a declared table with its stored chunk, so
+    /// a path that leaves the hashes directory - or smuggles separators past
+    /// it - would unpair the two.
+    #[error("hashtable chunk path is not directly under _meta_/hashes/: {0}")]
+    HashtablePathOutsideHashesDir(String),
+
+    /// One hashtable chunk path was declared twice with different content.
+    ///
+    /// Two manifest entries may declare one chunk (one table, two shapes),
+    /// but only over identical bytes - otherwise the declarations describe
+    /// two different tables under one path.
+    #[error("inconsistent content for hashtable chunk {0}")]
+    InconsistentHashtable(String),
+
     /// One chunk received different content for different WADs.
     ///
     /// Entries that share a `(path, layer)` identity are one chunk registered
@@ -85,6 +101,11 @@ pub struct ModpkgBuilder {
     license_text: Option<Vec<u8>>,
     thumbnail: Option<Vec<u8>>,
     metadata: ModpkgMetadata,
+    /// Declared tables, in declaration order: `(manifest entry, table bytes)`.
+    ///
+    /// The builder owns the manifest: `meta_chunks` writes these entries into
+    /// the metadata it serializes, so declaration and storage cannot disagree.
+    hashtables: Vec<(crate::ModpkgHashtable, Vec<u8>)>,
     // The WAD is part of the key so one chunk identity can be registered
     // under several WADs; see `with_chunk`.
     chunks: HashMap<(ChunkKey, WadNameHash), ModpkgChunkBuilder>,
@@ -97,14 +118,16 @@ type ContentKey = (u64, u64);
 /// A meta chunk to be written, resolved from the builder's content fields.
 #[derive(Debug)]
 struct MetaChunk<'builder> {
-    path: &'static str,
+    /// Borrowed for the four fixed chunks; hashtable chunk paths come from
+    /// the manifest, so the `Cow` is what lets both in.
+    path: Cow<'builder, str>,
     data: Cow<'builder, [u8]>,
     compression: ModpkgCompression,
 }
 
 impl MetaChunk<'_> {
     fn path_hash(&self) -> PathHash {
-        ChunkPath::new(self.path).hash()
+        ChunkPath::new(self.path.as_ref()).hash()
     }
 }
 
@@ -147,6 +170,59 @@ impl ModpkgBuilder {
         let key = chunk.full_key();
         self.chunks.insert(key, chunk);
         self
+    }
+
+    /// Declare an embedded hashtable and the chunk that stores it.
+    ///
+    /// `data` is the table file's bytes, copied verbatim like the readme and
+    /// license text - validation belongs to the caller that read the file.
+    /// The manifest entry is written into the metadata this builder
+    /// serializes, and the bytes into the chunk at `manifest.path`, so the
+    /// declaration and the stored chunk cannot disagree.
+    ///
+    /// One file, two shapes is legal: a second declaration of an
+    /// already-declared chunk path re-declares the stored chunk (the metadata
+    /// carries both entries, the chunk is stored once), so its bytes must be
+    /// identical to the first declaration's.
+    ///
+    /// # Errors
+    ///
+    /// [`ModpkgBuilderError::HashtablePathOutsideHashesDir`] when
+    /// `manifest.path` is not one the extraction placement rule
+    /// ([`hashtable_file_name`](crate::hashtable_file_name)) carries whole:
+    /// `_meta_/hashes/{plain file name}`.
+    /// [`ModpkgBuilderError::InconsistentHashtable`] when the chunk path was
+    /// already declared with different bytes.
+    pub fn with_hashtable(
+        mut self,
+        manifest: crate::ModpkgHashtable,
+        data: impl Into<Vec<u8>>,
+    ) -> Result<Self, ModpkgBuilderError> {
+        // Valid exactly when the placement rule carries the whole tail: the
+        // declared chunk and its extracted file then cannot part ways.
+        let tail = manifest
+            .path
+            .strip_prefix(crate::HASHTABLES_CHUNK_DIR)
+            .and_then(|rest| rest.strip_prefix('/'));
+        if tail.is_none() || crate::hashtable_file_name(&manifest.path) != tail {
+            return Err(ModpkgBuilderError::HashtablePathOutsideHashesDir(
+                manifest.path,
+            ));
+        }
+
+        let data = data.into();
+        let declared = self
+            .hashtables
+            .iter()
+            .find(|(existing, _)| existing.path.eq_ignore_ascii_case(&manifest.path));
+        if let Some((_, existing_data)) = declared {
+            if *existing_data != data {
+                return Err(ModpkgBuilderError::InconsistentHashtable(manifest.path));
+            }
+        }
+
+        self.hashtables.push((manifest, data));
+        Ok(self)
     }
 
     /// Build the Modpkg file and write it to the given writer.
@@ -352,18 +428,27 @@ impl ModpkgBuilder {
     /// is stored; the metadata chunk is always present, the rest follow their
     /// content field.
     fn meta_chunks(&self) -> Result<Vec<MetaChunk<'_>>, ModpkgBuilderError> {
+        // The builder owns the hashtable manifest: the entries declared with
+        // `with_hashtable` are what the serialized metadata carries, so the
+        // manifest and the stored chunks cannot disagree.
+        let mut metadata = self.metadata.clone();
+        metadata.hashtables = self
+            .hashtables
+            .iter()
+            .map(|(manifest, _)| manifest.clone())
+            .collect();
         let mut metadata_bytes = Vec::new();
-        self.metadata.write(&mut metadata_bytes)?;
+        metadata.write(&mut metadata_bytes)?;
 
         let mut meta_chunks = vec![MetaChunk {
-            path: METADATA_CHUNK_PATH,
+            path: Cow::Borrowed(METADATA_CHUNK_PATH),
             data: Cow::Owned(metadata_bytes),
             compression: ModpkgCompression::None,
         }];
 
         if let Some(thumbnail) = self.thumbnail.as_deref() {
             meta_chunks.push(MetaChunk {
-                path: THUMBNAIL_CHUNK_PATH,
+                path: Cow::Borrowed(THUMBNAIL_CHUNK_PATH),
                 data: Cow::Borrowed(thumbnail),
                 compression: ModpkgCompression::None,
             });
@@ -371,7 +456,7 @@ impl ModpkgBuilder {
 
         if let Some(readme) = self.readme.as_deref() {
             meta_chunks.push(MetaChunk {
-                path: README_CHUNK_PATH,
+                path: Cow::Borrowed(README_CHUNK_PATH),
                 data: Cow::Borrowed(readme),
                 compression: ModpkgCompression::None,
             });
@@ -382,10 +467,26 @@ impl ModpkgBuilder {
         // that don't pay for it fall back to raw storage in `write_meta_chunk`.
         if let Some(license_text) = self.license_text.as_deref() {
             meta_chunks.push(MetaChunk {
-                path: LICENSE_CHUNK_PATH,
+                path: Cow::Borrowed(LICENSE_CHUNK_PATH),
                 data: Cow::Borrowed(license_text),
                 compression: ModpkgCompression::Zstd,
             });
+        }
+
+        // Hashtables are line-per-name text, boilerplate-heavy like a
+        // license, so their chunks request Zstd too. A chunk two manifest
+        // entries declare (one table, two shapes; `with_hashtable` verified
+        // the bytes match) is stored once - the manifest above still carries
+        // every entry.
+        let mut stored_paths = HashSet::new();
+        for (manifest, data) in &self.hashtables {
+            if stored_paths.insert(manifest.path.to_ascii_lowercase()) {
+                meta_chunks.push(MetaChunk {
+                    path: Cow::Borrowed(manifest.path.as_str()),
+                    data: Cow::Borrowed(data),
+                    compression: ModpkgCompression::Zstd,
+                });
+            }
         }
 
         Ok(meta_chunks)
@@ -709,19 +810,19 @@ impl ModpkgChunkBuilder {
     /// The input must have a base filename of exactly 16 hexadecimal characters. Any number of
     /// extensions after the base is allowed (only the base is parsed). The `0x` prefix is NOT
     /// allowed.
-    /// The builder stores the provided (lowercased) string as the display path and parses the
-    /// base as hexadecimal for the `path_hash`.
+    /// The builder stores the (ASCII-lowercased) string as the chunk's stored path and parses
+    /// the base as hexadecimal for the `path_hash`.
     pub fn with_hashed_chunk_name(mut self, hashed_name: &str) -> Result<Self, ModpkgBuilderError> {
-        let display_path = hashed_name.to_lowercase();
+        let stored_path = hashed_name.to_ascii_lowercase();
 
-        let filename = Path::new(&display_path)
+        let filename = Path::new(&stored_path)
             .file_name()
             .and_then(|s| s.to_str())
-            .unwrap_or(&display_path);
+            .unwrap_or(&stored_path);
 
         self.path_hash = PathHash::from_hex_name(filename)
-            .ok_or_else(|| ModpkgBuilderError::InvalidChunkName(display_path.clone()))?;
-        self.path = display_path;
+            .ok_or_else(|| ModpkgBuilderError::InvalidChunkName(stored_path.clone()))?;
+        self.path = stored_path;
 
         Ok(self)
     }
@@ -746,7 +847,7 @@ impl ModpkgChunkBuilder {
     ///
     /// This enables efficient WAD-based lookups via the secondary index.
     pub fn with_wad(mut self, wad: &str) -> Self {
-        self.wad = wad.to_lowercase();
+        self.wad = wad.to_ascii_lowercase();
         self
     }
 
@@ -1255,14 +1356,177 @@ mod tests {
         assert!(ModpkgLayerBuilder::new("high-res").is_ok());
     }
 
+    fn game_manifest() -> crate::ModpkgHashtable {
+        crate::ModpkgHashtable {
+            path: "_meta_/hashes/game.hashes.txt".to_string(),
+            category: ltk_hashtable::Category::Game,
+            algorithm: ltk_hashtable::Algorithm::Xxh64,
+            bits: 64,
+        }
+    }
+
+    /// User story 34: a packed table comes back as a chunk the metadata
+    /// declares, so declaration and storage cannot disagree.
+    #[test]
+    fn a_hashtable_is_stored_as_a_meta_chunk_the_metadata_declares() {
+        let mut cursor = Cursor::new(Vec::new());
+        let names = "ASSETS/Custom/New.tex\nASSETS/Custom/Other.tex\n";
+
+        ModpkgBuilder::default()
+            .with_layer(ModpkgLayerBuilder::base())
+            .with_hashtable(game_manifest(), names)
+            .unwrap()
+            .build_to_writer(&mut cursor, |_| Ok(vec![0xAA; 10]))
+            .unwrap();
+
+        cursor.set_position(0);
+        let mut modpkg = Modpkg::mount_from_reader(cursor).unwrap();
+
+        assert_eq!(
+            modpkg.load_metadata().unwrap().hashtables(),
+            [game_manifest()]
+        );
+
+        let chunk = *modpkg.chunk("_meta_/hashes/game.hashes.txt", None).unwrap();
+        assert_eq!(chunk.layer(), None, "a meta chunk belongs to no layer");
+        assert_eq!(chunk.wad(), None, "a meta chunk belongs to no WAD");
+        assert_eq!(
+            modpkg.decoder().load_chunk_decompressed(&chunk).unwrap(),
+            names.as_bytes().into()
+        );
+    }
+
+    /// Table text is boilerplate-heavy like a license, so the chunk requests
+    /// Zstd; short tables that don't pay for it still fall back to raw.
+    #[test]
+    fn a_large_hashtable_is_stored_compressed() {
+        let mut cursor = Cursor::new(Vec::new());
+        let names: String = (0..2000)
+            .map(|i| format!("ASSETS/Characters/Aatrox/Skins/Skin{i}/Aatrox.dds\n"))
+            .collect();
+
+        ModpkgBuilder::default()
+            .with_layer(ModpkgLayerBuilder::base())
+            .with_hashtable(game_manifest(), names.clone())
+            .unwrap()
+            .build_to_writer(&mut cursor, |_| Ok(vec![0xAA; 10]))
+            .unwrap();
+
+        cursor.set_position(0);
+        let mut modpkg = Modpkg::mount_from_reader(cursor).unwrap();
+
+        let chunk = *modpkg.chunk("_meta_/hashes/game.hashes.txt", None).unwrap();
+        assert_eq!(chunk.compression, ModpkgCompression::Zstd);
+        assert_eq!(
+            modpkg.decoder().load_chunk_decompressed(&chunk).unwrap(),
+            names.as_bytes().into()
+        );
+    }
+
+    /// One file, two shapes: a repeated chunk path re-declares the stored
+    /// chunk, so the metadata carries both entries and the chunk is stored
+    /// once.
+    #[test]
+    fn a_chunk_declared_twice_keeps_both_entries_and_one_chunk() {
+        let names = "ASSETS/Custom/One.tex\n";
+        let narrow = crate::ModpkgHashtable {
+            bits: 32,
+            ..game_manifest()
+        };
+
+        let mut cursor = Cursor::new(Vec::new());
+        ModpkgBuilder::default()
+            .with_layer(ModpkgLayerBuilder::base())
+            .with_hashtable(game_manifest(), names)
+            .unwrap()
+            .with_hashtable(narrow.clone(), names)
+            .unwrap()
+            .build_to_writer(&mut cursor, |_| Ok(vec![0xAA; 10]))
+            .unwrap();
+
+        cursor.set_position(0);
+        let mut modpkg = Modpkg::mount_from_reader(cursor).unwrap();
+
+        assert_eq!(
+            modpkg.load_metadata().unwrap().hashtables(),
+            [game_manifest(), narrow]
+        );
+        let tables = modpkg.load_hashtables().unwrap();
+        assert_eq!(tables.len(), 2, "both declarations answer a load");
+    }
+
+    /// A repeated chunk path over different bytes is two tables under one
+    /// path, which no reader could tell apart - refused.
+    #[test]
+    fn a_chunk_declared_twice_with_different_bytes_is_refused() {
+        let result = ModpkgBuilder::default()
+            .with_hashtable(game_manifest(), "ASSETS/Custom/One.tex\n")
+            .unwrap()
+            .with_hashtable(game_manifest(), "ASSETS/Custom/Two.tex\n");
+
+        assert!(matches!(
+            result,
+            Err(ModpkgBuilderError::InconsistentHashtable(path)) if path.ends_with("game.hashes.txt")
+        ));
+    }
+
+    /// Chunk paths are case-insensitive, so declarations that differ only in
+    /// case are one chunk - and one chunk over different bytes is refused
+    /// just like an exact repeat.
+    #[test]
+    fn a_chunk_declared_under_case_variant_paths_with_different_bytes_is_refused() {
+        let cased = crate::ModpkgHashtable {
+            path: "_meta_/hashes/Game.hashes.txt".to_string(),
+            ..game_manifest()
+        };
+
+        let result = ModpkgBuilder::default()
+            .with_hashtable(cased, "ASSETS/Custom/One.tex\n")
+            .unwrap()
+            .with_hashtable(game_manifest(), "ASSETS/Custom/Two.tex\n");
+
+        assert!(matches!(
+            result,
+            Err(ModpkgBuilderError::InconsistentHashtable(path))
+                if path.eq_ignore_ascii_case("_meta_/hashes/game.hashes.txt")
+        ));
+    }
+
+    /// The manifest names where the chunk goes; a path outside `_meta_/hashes/`
+    /// (or one smuggling separators past it) would unpair declaration from
+    /// storage, so it is refused at the seam.
+    #[test]
+    fn a_hashtable_declared_outside_the_hashes_dir_is_refused() {
+        for path in [
+            "hashes/game.hashes.txt",
+            "_meta_/hashes/../license",
+            "_meta_/hashes/sub/dir.txt",
+            "_meta_/hashes/",
+            "_meta_/hashes/.",
+        ] {
+            let manifest = crate::ModpkgHashtable {
+                path: path.to_string(),
+                ..game_manifest()
+            };
+            assert!(
+                ModpkgBuilder::default()
+                    .with_hashtable(manifest, "a/b.txt\n")
+                    .is_err(),
+                "{path} should be refused"
+            );
+        }
+    }
+
     #[test]
     fn with_path_normalizes_backslashes() {
         let chunk = ModpkgChunkBuilder::new()
             .with_path("ASSETS\\Characters\\Aatrox\\Skins\\Base\\Aatrox.dds");
 
-        assert_eq!(chunk.path, "assets/characters/aatrox/skins/base/aatrox.dds");
+        // The stored path keeps the authored casing (ADR 0003); only the
+        // separators normalize.
+        assert_eq!(chunk.path, "ASSETS/Characters/Aatrox/Skins/Base/Aatrox.dds");
 
-        // Hash should match the normalized forward-slash version
+        // Identity is the canonical name, so any spelling hashes alike.
         let forward =
             ModpkgChunkBuilder::new().with_path("assets/characters/aatrox/skins/base/aatrox.dds");
 
@@ -1291,22 +1555,23 @@ mod tests {
         cursor.set_position(0);
         let modpkg = Modpkg::mount_from_reader(&mut cursor).unwrap();
 
-        // Stored path must be normalized
-        let normalized = "assets/characters/aatrox/aatrox.dds";
-        let path_hash = ChunkPath::new(normalized).hash();
+        // The stored path keeps the authored casing with separators
+        // normalized (ADR 0003), and is keyed by its canonical name's hash.
+        let stored = "ASSETS/Characters/Aatrox/Aatrox.dds";
+        let path_hash = ChunkPath::new("assets/characters/aatrox/aatrox.dds").hash();
 
         assert_eq!(
             modpkg.chunk_paths().get(&path_hash),
-            Some(&normalized.to_string()),
-            "chunk_paths should contain the normalized path"
+            Some(&stored.to_string()),
+            "chunk_paths should hold the stored path under the canonical hash"
         );
 
-        // Chunk should be findable by the normalized hash
+        // Chunk should be findable by the canonical hash
         assert!(
             modpkg
                 .chunks()
                 .contains_key(&ChunkKey::new(path_hash, LayerHash::from_name("base"))),
-            "chunk should be retrievable with normalized path hash"
+            "chunk should be retrievable with the canonical path hash"
         );
     }
 }

--- a/crates/ltk_modpkg/src/chunk_path.rs
+++ b/crates/ltk_modpkg/src/chunk_path.rs
@@ -4,50 +4,102 @@ use xxhash_rust::xxh64;
 
 use crate::PathHash;
 
-/// A chunk path in canonical form: lowercase, forward slashes.
+/// A chunk's stored path: the authored casing, forward slashes.
 ///
 /// This is the path the file has *inside its target WAD*, matching what the
 /// game ships. The WAD it belongs to and the layer it came from are stored
 /// separately on the chunk, so neither the `.wad.client` directory nor the
 /// layer name appears here.
 ///
+/// Two forms of one path (ADR 0003): the **stored path** is the authored form
+/// this type holds and [`as_str`](Self::as_str) returns; the **canonical
+/// name** is its ASCII-lowercased form, which is what gets hashed and what
+/// identity means. The canonical string itself is never exposed -
+/// [`hash`](Self::hash) is the identity, and equality, ordering and
+/// [`std::hash::Hash`] all judge the canonical name, so two spellings of one
+/// path are one `ChunkPath`. ASCII-lowercasing matches every other hash space
+/// in the workspace (`ltk_hashtable`'s keys, `ltk_hash`).
+///
 /// Chunks are keyed by the hash of their path, so a hash taken over a
-/// denormalized path silently matches nothing. Normalization happens once, in
-/// the constructor, which makes that state unrepresentable rather than merely
-/// documented.
+/// denormalized path silently matches nothing. Separator normalization happens
+/// once, in the constructor, and the lowercasing lives inside [`hash`](Self::hash),
+/// which makes those states unrepresentable rather than merely documented.
 ///
 /// ```
 /// use ltk_modpkg::ChunkPath;
 ///
 /// let path = ChunkPath::new("ASSETS\\Characters\\Aatrox\\Skins\\Base\\Aatrox.dds");
 ///
-/// assert_eq!(path.as_str(), "assets/characters/aatrox/skins/base/aatrox.dds");
+/// // The stored path keeps the authored casing...
+/// assert_eq!(path.as_str(), "ASSETS/Characters/Aatrox/Skins/Base/Aatrox.dds");
+/// // ...and identity is the canonical name.
 /// assert_eq!(
 ///     path.hash(),
 ///     ChunkPath::new("assets/characters/aatrox/skins/base/aatrox.dds").hash()
 /// );
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Default)]
 pub struct ChunkPath(String);
 
 impl ChunkPath {
-    /// Normalize `path` into a chunk path.
+    /// Normalize `path`'s separators into a chunk path, keeping its casing.
     pub fn new(path: impl AsRef<str>) -> Self {
-        Self(path.as_ref().to_lowercase().replace('\\', "/"))
+        Self(path.as_ref().replace('\\', "/"))
     }
 
-    /// The xxhash64 of the canonical path, as stored in the chunk table.
+    /// The xxhash64 of the canonical name, as stored in the chunk table.
     pub fn hash(&self) -> PathHash {
-        PathHash::new(xxh64::xxh64(self.0.as_bytes(), 0))
+        PathHash::new(xxh64::xxh64(self.0.to_ascii_lowercase().as_bytes(), 0))
     }
 
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
-    /// Consume the path, yielding the canonical string.
+    /// Consume the path, yielding the stored string.
     pub fn into_string(self) -> String {
         self.0
+    }
+
+    /// The canonical name, one byte at a time, without allocating.
+    ///
+    /// The same ASCII-lowercasing [`hash`](Self::hash) applies, so everything
+    /// that judges identity judges the same bytes.
+    fn canonical_bytes(&self) -> impl Iterator<Item = u8> + '_ {
+        self.0.bytes().map(|byte| byte.to_ascii_lowercase())
+    }
+}
+
+// Identity is the canonical name (ADR 0003): implemented by hand rather than
+// derived so two spellings of one path stay equal now that the stored bytes
+// keep their casing. `Hash` must agree with `Eq`, so it feeds the same
+// lowercased bytes.
+
+impl PartialEq for ChunkPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq_ignore_ascii_case(&other.0)
+    }
+}
+
+impl Eq for ChunkPath {}
+
+impl std::hash::Hash for ChunkPath {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for byte in self.canonical_bytes() {
+            state.write_u8(byte);
+        }
+    }
+}
+
+impl PartialOrd for ChunkPath {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ChunkPath {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.canonical_bytes().cmp(other.canonical_bytes())
     }
 }
 
@@ -82,16 +134,18 @@ mod tests {
     const IN_WAD: &str = "ASSETS/Characters/Aatrox/Skins/Base/Aatrox.dds";
     const CANONICAL: &str = "assets/characters/aatrox/skins/base/aatrox.dds";
 
+    /// ADR 0003: the stored path is the authored form. Lowercasing it flattened
+    /// every modpkg extraction.
     #[test]
-    fn new_lowercases() {
-        assert_eq!(ChunkPath::new(IN_WAD).as_str(), CANONICAL);
+    fn new_keeps_the_authored_casing() {
+        assert_eq!(ChunkPath::new(IN_WAD).as_str(), IN_WAD);
     }
 
     #[test]
     fn new_converts_backslashes() {
         assert_eq!(
-            ChunkPath::new("assets\\characters\\aatrox\\skins\\base\\aatrox.dds").as_str(),
-            CANONICAL
+            ChunkPath::new("ASSETS\\Characters\\Aatrox\\Skins\\Base\\Aatrox.dds").as_str(),
+            IN_WAD
         );
     }
 
@@ -100,7 +154,49 @@ mod tests {
         let once = ChunkPath::new("ASSETS\\Characters/Aatrox\\Skins/Base/Aatrox.dds");
         let twice = ChunkPath::new(once.as_str());
 
-        assert_eq!(once, twice);
+        assert_eq!(once.as_str(), twice.as_str());
+    }
+
+    /// Two spellings of one path were the same `ChunkPath` before ADR 0003 and
+    /// must still be: identity is the canonical name, not the stored path.
+    #[test]
+    fn spellings_of_one_path_are_equal_and_hash_alike() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let authored = ChunkPath::new(IN_WAD);
+        let flattened = ChunkPath::new(CANONICAL);
+
+        assert_eq!(authored, flattened);
+        assert_eq!(authored.cmp(&flattened), std::cmp::Ordering::Equal);
+
+        // Qualified because the inherent `hash()` (the xxh64) shadows the
+        // trait method.
+        let mut first = DefaultHasher::new();
+        Hash::hash(&authored, &mut first);
+        let mut second = DefaultHasher::new();
+        Hash::hash(&flattened, &mut second);
+        assert_eq!(first.finish(), second.finish());
+    }
+
+    /// Canonicalization is ASCII-lowercasing, matching `ltk_hashtable`'s keys
+    /// and `ltk_hash`: a non-ASCII character never folds, so `É` and `é` are
+    /// two different chunks.
+    #[test]
+    fn canonicalization_is_ascii_only() {
+        assert_ne!(
+            ChunkPath::new("data/É.bin").hash(),
+            ChunkPath::new("data/é.bin").hash()
+        );
+        assert_ne!(ChunkPath::new("data/É.bin"), ChunkPath::new("data/é.bin"));
+    }
+
+    /// Case decides nothing, so ordering falls to what differs after it.
+    #[test]
+    fn ordering_is_case_insensitive() {
+        // A derived (byte-wise) order would put `B` (0x42) before `a` (0x61).
+        assert!(ChunkPath::new("B/x.bin") > ChunkPath::new("a/y.bin"));
+        assert!(ChunkPath::new("a/x.bin") < ChunkPath::new("B/y.bin"));
     }
 
     /// The whole point of the type: paths that differ only in case or

--- a/crates/ltk_modpkg/src/error.rs
+++ b/crates/ltk_modpkg/src/error.rs
@@ -66,6 +66,17 @@ pub enum ModpkgError {
     #[error("Invalid meta chunk: must not belong to any layer or wad")]
     InvalidMetaChunk,
 
+    /// The metadata declares a hashtable whose chunk the package does not hold.
+    #[error("Missing hashtable chunk: {path}")]
+    MissingHashtable { path: String },
+
+    /// A declared hashtable chunk does not fit the table grammar.
+    #[error("Invalid hashtable: {path}")]
+    InvalidHashtable {
+        path: String,
+        source: ltk_hashtable::HashtableReadError,
+    },
+
     /// A chunk path, layer name or WAD name leaves the directory the package
     /// would be extracted to, so extracting it would write outside it.
     ///

--- a/crates/ltk_modpkg/src/extractor.rs
+++ b/crates/ltk_modpkg/src/extractor.rs
@@ -85,14 +85,14 @@ impl<'modpkg, TSource: Read + Seek> ModpkgExtractor<'modpkg, TSource> {
     /// Write the meta chunks that have a project-level file form to `output_dir`.
     ///
     /// That is the readme, the license text and the thumbnail, under the names
-    /// a mod project keeps them at its root. Chunks without such a form (the
-    /// metadata chunk, which is msgpack rather than a project file) are skipped
-    /// rather than dumped under `_meta_/`; read it with
-    /// [`Modpkg::load_metadata`] instead.
+    /// a mod project keeps them at its root, and the hashtables, under
+    /// `hashes/`. Chunks without such a form (the metadata chunk, which is
+    /// msgpack rather than a project file) are skipped rather than dumped
+    /// under `_meta_/`; read it with [`Modpkg::load_metadata`] instead.
     pub fn extract_meta(&mut self, output_dir: impl AsRef<Path>) -> Result<(), ModpkgError> {
         let output_dir = output_dir.as_ref();
 
-        let steps = steps(&self.modpkg.extraction_plan().root_files(), output_dir);
+        let steps = steps(&self.modpkg.extraction_plan().meta_files(), output_dir);
         self.write_all(steps)
     }
 
@@ -321,6 +321,55 @@ mod tests {
         assert!(
             !content.join("README.md").exists(),
             "meta files must not leak into the content directory"
+        );
+    }
+
+    /// A hashtable is a meta chunk with a project-level file form: it lands
+    /// under `hashes/` beside the content, from the same call that writes the
+    /// root files, for both the look-at unpack and the project import.
+    #[test]
+    fn extract_meta_writes_hashtables_under_the_hashes_directory() {
+        let mut cursor = Cursor::new(Vec::new());
+        let names = "ASSETS/Custom/One.tex\n";
+
+        ModpkgBuilder::default()
+            .with_layer(ModpkgLayerBuilder::base())
+            .with_readme("# My Mod\n")
+            .with_hashtable(
+                crate::ModpkgHashtable {
+                    path: "_meta_/hashes/game.hashes.txt".to_string(),
+                    category: ltk_hashtable::Category::Game,
+                    algorithm: ltk_hashtable::Algorithm::Xxh64,
+                    bits: 64,
+                },
+                names,
+            )
+            .unwrap()
+            .with_chunk(
+                ModpkgChunkBuilder::new()
+                    .with_path("test.bin")
+                    .with_compression(ModpkgCompression::None),
+            )
+            .build_to_writer(&mut cursor, |_| Ok(vec![0xAA; 10]))
+            .unwrap();
+
+        cursor.set_position(0);
+        let mut modpkg = Modpkg::mount_from_reader(cursor).unwrap();
+
+        let temp_dir = tempdir().unwrap();
+        let root = temp_dir.path();
+        ModpkgExtractor::new(&mut modpkg)
+            .extract_meta(root)
+            .unwrap();
+
+        assert_eq!(
+            fs::read(root.join("hashes").join("game.hashes.txt")).unwrap(),
+            names.as_bytes()
+        );
+        assert_eq!(fs::read(root.join("README.md")).unwrap(), b"# My Mod\n");
+        assert!(
+            !root.join("base").exists(),
+            "extract_meta must not write layer content"
         );
     }
 

--- a/crates/ltk_modpkg/src/hashes.rs
+++ b/crates/ltk_modpkg/src/hashes.rs
@@ -70,9 +70,9 @@ impl LayerHash {
 
     /// Hash a layer name.
     ///
-    /// The name is lowercased first, so the hash is case-insensitive.
+    /// The name is ASCII-lowercased first, so the hash is case-insensitive.
     pub fn from_name(name: &str) -> Self {
-        Self(xxh3_64(name.to_lowercase().as_bytes()))
+        Self(xxh3_64(name.to_ascii_lowercase().as_bytes()))
     }
 
     /// Wrap a raw hash value.
@@ -102,9 +102,9 @@ impl WadNameHash {
 
     /// Hash a WAD name.
     ///
-    /// The name is lowercased first, so the hash is case-insensitive.
+    /// The name is ASCII-lowercased first, so the hash is case-insensitive.
     pub fn from_name(name: &str) -> Self {
-        Self(xxh3_64(name.to_lowercase().as_bytes()))
+        Self(xxh3_64(name.to_ascii_lowercase().as_bytes()))
     }
 
     /// Wrap a raw hash value.

--- a/crates/ltk_modpkg/src/hashtable.rs
+++ b/crates/ltk_modpkg/src/hashtable.rs
@@ -1,0 +1,221 @@
+//! The modpkg spelling of the embedded-hashtables manifest.
+//!
+//! Each container spells `ltk_hashtable`'s domain entry its own way; this is
+//! the modpkg one, carried in [`ModpkgMetadata::hashtables`] at schema
+//! version 3. The manifest is authoritative: a chunk under
+//! [`HASHTABLES_CHUNK_DIR`] that no manifest entry declares does not exist
+//! for lookup.
+//!
+//! [`ModpkgMetadata::hashtables`]: crate::ModpkgMetadata::hashtables
+
+use serde::{Deserialize, Serialize};
+
+/// The chunk directory hashtable chunks are stored under.
+///
+/// A table's chunk path is `_meta_/hashes/{file name}`: the file name is the
+/// one the mod project keeps under its `hashes/` directory, so project ->
+/// modpkg -> project loses no table names.
+pub const HASHTABLES_CHUNK_DIR: &str = "_meta_/hashes";
+
+/// One embedded hashtable, as the metadata declares it.
+///
+/// The modpkg spelling of `ltk_hashtable`'s `HashtableEntry`: snake_case keys
+/// in the msgpack metadata chunk, `path` naming the table's chunk. Convert
+/// with [`to_entry`](Self::to_entry) and [`from_entry`](Self::from_entry).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ModpkgHashtable {
+    /// The table's chunk path, e.g. `_meta_/hashes/game.hashes.txt`.
+    pub path: String,
+    /// The lookup domain of the table's names.
+    pub category: ltk_hashtable::Category,
+    /// The hash function keying the table's names.
+    pub algorithm: ltk_hashtable::Algorithm,
+    /// The declared key width in bits.
+    pub bits: u8,
+}
+
+impl ModpkgHashtable {
+    /// The entry as `ltk_hashtable`'s domain type.
+    ///
+    /// `None` when `bits` declares a width no key can have; the standard
+    /// requires `1..=64`.
+    pub fn to_entry(&self) -> Option<ltk_hashtable::HashtableEntry> {
+        let width = ltk_hashtable::KeyWidth::new(self.bits)?;
+        Some(ltk_hashtable::HashtableEntry::new(
+            self.path.as_str(),
+            self.category.clone(),
+            self.algorithm.clone(),
+            width,
+        ))
+    }
+
+    /// Spell a domain entry the modpkg way.
+    pub fn from_entry(entry: &ltk_hashtable::HashtableEntry) -> Self {
+        Self {
+            path: entry.path().to_string(),
+            category: entry.category().clone(),
+            algorithm: entry.algorithm().clone(),
+            bits: entry.width().bits(),
+        }
+    }
+}
+
+impl<TSource: std::io::Read + std::io::Seek> crate::Modpkg<TSource> {
+    /// Load the hashtables the metadata declares - and only those.
+    ///
+    /// A chunk under `_meta_/hashes/` that no manifest entry declares is not
+    /// a table and is not read; the manifest is authoritative. An entry whose
+    /// declared width is not one a key can have is skipped rather than
+    /// refused - it still travels with the package, it just cannot answer a
+    /// lookup here.
+    ///
+    /// The pairs feed `ltk_hashtable::HashtableSet::build` as they are, in
+    /// manifest order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the package cannot be read, a declared table chunk
+    /// is missing, or one does not fit the table grammar.
+    pub fn load_hashtables(
+        &mut self,
+    ) -> Result<Vec<(ltk_hashtable::HashtableEntry, ltk_hashtable::Hashtable)>, crate::ModpkgError>
+    {
+        let manifests = self.load_metadata()?.hashtables;
+        let mut tables = Vec::new();
+        for manifest in manifests {
+            let Some(entry) = manifest.to_entry() else {
+                continue;
+            };
+            let chunk = *self.chunk(&manifest.path, None).map_err(|error| {
+                // Named by path rather than hash: the manifest holds the
+                // path, and a hex hash names nothing to a user.
+                match error {
+                    crate::ModpkgError::MissingChunk(_) => crate::ModpkgError::MissingHashtable {
+                        path: manifest.path.clone(),
+                    },
+                    other => other,
+                }
+            })?;
+            if chunk.layer().is_some() || chunk.wad().is_some() {
+                return Err(crate::ModpkgError::InvalidMetaChunk);
+            }
+            let data = self.decoder().load_chunk_decompressed(&chunk)?;
+            let table = ltk_hashtable::Hashtable::from_reader(&*data).map_err(|source| {
+                crate::ModpkgError::InvalidHashtable {
+                    path: manifest.path.clone(),
+                    source,
+                }
+            })?;
+            tables.push((entry, table));
+        }
+        Ok(tables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::{ModpkgBuilder, ModpkgLayerBuilder};
+    use crate::Modpkg;
+    use std::io::Cursor;
+
+    fn manifest(file_name: &str, bits: u8) -> ModpkgHashtable {
+        ModpkgHashtable {
+            path: format!("{HASHTABLES_CHUNK_DIR}/{file_name}"),
+            category: ltk_hashtable::Category::Game,
+            algorithm: ltk_hashtable::Algorithm::Xxh64,
+            bits,
+        }
+    }
+
+    fn package(
+        tables: impl IntoIterator<Item = (ModpkgHashtable, &'static str)>,
+    ) -> Modpkg<Cursor<Vec<u8>>> {
+        let mut builder = ModpkgBuilder::default().with_layer(ModpkgLayerBuilder::base());
+        for (manifest, data) in tables {
+            builder = builder.with_hashtable(manifest, data).unwrap();
+        }
+        let mut cursor = Cursor::new(Vec::new());
+        builder
+            .build_to_writer(&mut cursor, |_| Ok(vec![0xAA; 10]))
+            .unwrap();
+        cursor.set_position(0);
+        Modpkg::mount_from_reader(cursor).unwrap()
+    }
+
+    /// The pairs come back in manifest order, because `HashtableSet::build`
+    /// merges in manifest order and first declaration wins.
+    #[test]
+    fn declared_tables_load_in_manifest_order() {
+        let mut modpkg = package([
+            (manifest("game.hashes.txt", 64), "ASSETS/Custom/One.tex\n"),
+            (
+                manifest("game.imported.hashes.txt", 64),
+                "ASSETS/Custom/Two.tex\n",
+            ),
+        ]);
+
+        let tables = modpkg.load_hashtables().unwrap();
+
+        let loaded: Vec<(&str, Vec<&str>)> = tables
+            .iter()
+            .map(|(entry, table)| (entry.path().as_str(), table.names().collect()))
+            .collect();
+        assert_eq!(
+            loaded,
+            [
+                (
+                    "_meta_/hashes/game.hashes.txt",
+                    vec!["ASSETS/Custom/One.tex"]
+                ),
+                (
+                    "_meta_/hashes/game.imported.hashes.txt",
+                    vec!["ASSETS/Custom/Two.tex"]
+                ),
+            ]
+        );
+    }
+
+    /// An entry whose width no key can have is skipped, not refused: it still
+    /// travels with the package, it just cannot answer a lookup here.
+    #[test]
+    fn an_impossible_width_is_skipped_rather_than_refused() {
+        let mut modpkg = package([
+            (manifest("game.hashes.txt", 0), "ASSETS/Custom/One.tex\n"),
+            (
+                manifest("game.ok.hashes.txt", 64),
+                "ASSETS/Custom/Two.tex\n",
+            ),
+        ]);
+
+        let tables = modpkg.load_hashtables().unwrap();
+
+        assert_eq!(tables.len(), 1);
+        assert_eq!(tables[0].0.path(), "_meta_/hashes/game.ok.hashes.txt");
+    }
+
+    /// A declared chunk that does not fit the table grammar fails the load,
+    /// named by the path the manifest declared.
+    #[test]
+    fn a_table_outside_the_grammar_fails_by_its_declared_path() {
+        let mut modpkg = package([(manifest("game.hashes.txt", 64), "\u{feff}bom.tex\n")]);
+
+        let error = modpkg.load_hashtables().unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::ModpkgError::InvalidHashtable { ref path, .. }
+                if path == "_meta_/hashes/game.hashes.txt"
+        ));
+    }
+
+    /// A package declaring no tables loads none - including one written
+    /// before schema v3.
+    #[test]
+    fn a_package_without_tables_loads_none() {
+        let mut modpkg = package([]);
+
+        assert!(modpkg.load_hashtables().unwrap().is_empty());
+    }
+}

--- a/crates/ltk_modpkg/src/lib.rs
+++ b/crates/ltk_modpkg/src/lib.rs
@@ -13,6 +13,7 @@ mod decoder;
 pub mod error;
 mod extractor;
 mod hashes;
+mod hashtable;
 mod indices;
 mod license;
 mod metadata;
@@ -28,10 +29,13 @@ pub use decoder::ModpkgDecoder;
 pub use error::{InvalidSlugError, ModpkgError};
 pub use extractor::ModpkgExtractor;
 pub use hashes::{ChunkKey, LayerHash, PathHash, WadNameHash};
+pub use hashtable::{ModpkgHashtable, HASHTABLES_CHUNK_DIR};
 pub use indices::{LayerIndex, WadIndex};
 pub use license::*;
 pub use metadata::*;
-pub use plan::{ChunkDestination, ExtractionPlan, PlannedChunk};
+pub use plan::{
+    hashtable_file_name, ChunkDestination, ExtractionPlan, PlannedChunk, HASHES_DIR_NAME,
+};
 pub use readme::*;
 pub use slug::Slug;
 pub use thumbnail::*;

--- a/crates/ltk_modpkg/src/metadata.rs
+++ b/crates/ltk_modpkg/src/metadata.rs
@@ -1,4 +1,4 @@
-use crate::{error::ModpkgError, license::ModpkgLicense, Modpkg};
+use crate::{error::ModpkgError, hashtable::ModpkgHashtable, license::ModpkgLicense, Modpkg};
 use indexmap::IndexMap;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -193,6 +193,32 @@ pub struct ModpkgMetadata {
         )
     )]
     pub layers: Vec<ModpkgLayerMetadata>,
+
+    /// The embedded hashtables the package declares (added in schema v3).
+    ///
+    /// The manifest is authoritative: a chunk under `_meta_/hashes/` that no
+    /// entry here declares does not exist for lookup. Absent from packages
+    /// written before schema v3, and omitted when empty so a package without
+    /// tables serializes byte-identically to one written before this field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[cfg_attr(test, proptest(strategy = "hashtables_strategy()"))]
+    pub hashtables: Vec<ModpkgHashtable>,
+}
+
+/// Proptest strategy for [`ModpkgMetadata::hashtables`].
+#[cfg(test)]
+fn hashtables_strategy() -> impl proptest::strategy::Strategy<Value = Vec<ModpkgHashtable>> {
+    use proptest::strategy::Strategy;
+
+    proptest::collection::vec(
+        ("[a-z0-9.-]{1,20}", 1u8..=64).prop_map(|(name, bits)| ModpkgHashtable {
+            path: format!("_meta_/hashes/{name}"),
+            category: ltk_hashtable::Category::Game,
+            algorithm: ltk_hashtable::Algorithm::Xxh64,
+            bits,
+        }),
+        0..3,
+    )
 }
 
 impl Default for ModpkgMetadata {
@@ -210,15 +236,16 @@ impl Default for ModpkgMetadata {
             champions: Vec::new(),
             maps: Vec::new(),
             layers: Vec::new(),
+            hashtables: Vec::new(),
         }
     }
 }
 
 /// Current metadata schema version.
-pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
 fn default_schema_version() -> u32 {
-    2
+    CURRENT_SCHEMA_VERSION
 }
 
 impl ModpkgMetadata {
@@ -294,6 +321,11 @@ impl ModpkgMetadata {
     /// Get the per-layer metadata entries, if any.
     pub fn layers(&self) -> &[ModpkgLayerMetadata] {
         &self.layers
+    }
+
+    /// Get the embedded hashtables the package declares.
+    pub fn hashtables(&self) -> &[ModpkgHashtable] {
+        &self.hashtables
     }
 }
 
@@ -372,6 +404,7 @@ mod tests {
             champions: vec![],
             maps: vec![],
             layers: vec![],
+            hashtables: vec![],
         };
         let mut cursor = Cursor::new(Vec::new());
         metadata.write(&mut cursor).unwrap();
@@ -407,6 +440,7 @@ mod tests {
             champions: vec![],
             maps: vec![],
             layers: vec![],
+            hashtables: vec![],
         };
 
         let encoded = rmp_serde::to_vec_named(&metadata).unwrap();
@@ -478,6 +512,116 @@ mod tests {
         assert_eq!(layer, decoded);
     }
 
+    /// A metadata map with no `schema_version` key reads as CURRENT. Every
+    /// writer, v1 onward, writes the key explicitly, so this only decides
+    /// hand-built msgpack - and the default deliberately tracks
+    /// [`CURRENT_SCHEMA_VERSION`], the crate's standing pattern. This test
+    /// exists so the next version bump makes the same move consciously.
+    #[test]
+    fn a_missing_schema_version_key_reads_as_current() {
+        #[derive(Serialize)]
+        #[serde(rename_all = "snake_case")]
+        struct VersionlessWriter {
+            name: String,
+            display_name: String,
+            description: Option<String>,
+            version: Version,
+            distributor: Option<DistributorInfo>,
+            authors: Vec<ModpkgAuthor>,
+            license: ModpkgLicense,
+        }
+
+        let encoded = rmp_serde::to_vec_named(&VersionlessWriter {
+            name: "keyless".to_string(),
+            display_name: "Keyless".to_string(),
+            description: None,
+            version: Version::new(1, 0, 0),
+            distributor: None,
+            authors: vec![],
+            license: ModpkgLicense::None,
+        })
+        .unwrap();
+
+        let decoded = ModpkgMetadata::read(&mut Cursor::new(encoded)).unwrap();
+        assert_eq!(decoded.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    /// Schema v3 is additive: a v3 package must read on a v2 reader, with the
+    /// hashtables ignored - the correct outcome for a reader that could not
+    /// have used them.
+    #[test]
+    fn v3_metadata_decodes_with_a_v2_reader() {
+        #[derive(Debug, Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        struct V2Metadata {
+            name: String,
+        }
+
+        let metadata = ModpkgMetadata {
+            name: "v3-mod".to_string(),
+            hashtables: vec![ModpkgHashtable {
+                path: "_meta_/hashes/game.hashes.txt".to_string(),
+                category: ltk_hashtable::Category::Game,
+                algorithm: ltk_hashtable::Algorithm::Xxh64,
+                bits: 64,
+            }],
+            ..ModpkgMetadata::default()
+        };
+
+        let mut cursor = Cursor::new(Vec::new());
+        metadata.write(&mut cursor).unwrap();
+
+        let decoded: V2Metadata = rmp_serde::from_slice(cursor.get_ref()).unwrap();
+        assert_eq!(decoded.name, "v3-mod");
+    }
+
+    /// A v2 package carries no `hashtables` key; the v3 reader must decode it
+    /// with the field empty rather than failing the whole metadata chunk.
+    #[test]
+    fn v2_metadata_decodes_with_no_hashtables() {
+        let v2 = ModpkgMetadata {
+            schema_version: 2,
+            name: "old-mod".to_string(),
+            ..ModpkgMetadata::default()
+        };
+        let encoded = rmp_serde::to_vec_named(&v2).unwrap();
+        assert!(!String::from_utf8_lossy(&encoded).contains("hashtables"));
+
+        let decoded = ModpkgMetadata::read(&mut Cursor::new(encoded)).unwrap();
+        assert!(decoded.hashtables.is_empty());
+    }
+
+    /// A package without tables serializes byte-identically to one written
+    /// before the field existed.
+    #[test]
+    fn empty_hashtables_are_omitted_from_the_wire() {
+        let encoded = rmp_serde::to_vec_named(&ModpkgMetadata::default()).unwrap();
+        assert!(!String::from_utf8_lossy(&encoded).contains("hashtables"));
+    }
+
+    #[test]
+    fn hashtables_roundtrip_through_the_metadata_chunk() {
+        let manifest = ModpkgHashtable {
+            path: "_meta_/hashes/game.imported.hashes.txt".to_string(),
+            category: ltk_hashtable::Category::Unknown("wadnames".to_string()),
+            algorithm: ltk_hashtable::Algorithm::Unknown("crc32".to_string()),
+            bits: 32,
+        };
+        let metadata = ModpkgMetadata {
+            hashtables: vec![manifest.clone()],
+            ..ModpkgMetadata::default()
+        };
+
+        let mut cursor = Cursor::new(Vec::new());
+        metadata.write(&mut cursor).unwrap();
+        cursor.set_position(0);
+
+        let read = ModpkgMetadata::read(&mut cursor).unwrap();
+        // Unknown categories and algorithms round-trip verbatim: the open
+        // registries keep their spelling.
+        assert_eq!(read.hashtables, [manifest]);
+    }
+
     #[test]
     fn test_v1_metadata_backward_compat() {
         // Simulate a v1 metadata without string_overrides on layers
@@ -500,6 +644,7 @@ mod tests {
                 description: None,
                 string_overrides: IndexMap::new(),
             }],
+            hashtables: vec![],
         };
 
         let mut cursor = Cursor::new(Vec::new());
@@ -553,6 +698,7 @@ mod tests {
                     )]),
                 },
             ],
+            hashtables: vec![],
         };
 
         let mut cursor = Cursor::new(Vec::new());

--- a/crates/ltk_modpkg/src/plan.rs
+++ b/crates/ltk_modpkg/src/plan.rs
@@ -17,9 +17,16 @@ use std::{
 };
 
 use crate::{
-    chunk::ModpkgChunk, LayerIndex, Modpkg, WadIndex, LICENSE_CHUNK_PATH, README_CHUNK_PATH,
-    THUMBNAIL_CHUNK_PATH,
+    chunk::ModpkgChunk, LayerIndex, Modpkg, WadIndex, HASHTABLES_CHUNK_DIR, LICENSE_CHUNK_PATH,
+    README_CHUNK_PATH, THUMBNAIL_CHUNK_PATH,
 };
+
+/// The directory hashtables land under, beside the content.
+///
+/// A mod project keeps its tables under `hashes/` at its root; this constant
+/// and that layout agree the way [`ChunkDestination::Root`]'s names agree
+/// with the files a project keeps.
+pub const HASHES_DIR_NAME: &str = "hashes";
 
 /// Every chunk an unpack of a package writes, and where each one lands.
 ///
@@ -55,12 +62,23 @@ impl<'pkg> ExtractionPlan<'pkg> {
     /// The part of the plan that lands at the root: the readme, the license
     /// text and the thumbnail.
     ///
-    /// The package's meta chunks, which it stores under `_meta_/` but which do
-    /// not land there: they come out under the names a mod project keeps them
-    /// at, beside its content rather than inside it. This is what
+    /// Meta chunks the package stores under `_meta_/` but which do not land
+    /// there: they come out under the names a mod project keeps them at,
+    /// beside its content rather than inside it. Hashtables are not root
+    /// files - they land under `hashes/` - so they are not here; the private
+    /// `meta_files` narrowing is everything
     /// [`extract_meta`](crate::ModpkgExtractor::extract_meta) writes.
     pub fn root_files(&self) -> Self {
         self.retaining(|destination| matches!(destination, ChunkDestination::Root(_)))
+    }
+
+    /// The part of the plan that is not layer content: the root files and the
+    /// hashtables.
+    ///
+    /// This is what [`extract_meta`](crate::ModpkgExtractor::extract_meta)
+    /// writes.
+    pub(crate) fn meta_files(&self) -> Self {
+        self.retaining(|destination| !matches!(destination, ChunkDestination::Content { .. }))
     }
 
     /// The plan narrowed to the chunks whose destination `keep` accepts.
@@ -141,6 +159,22 @@ pub enum ChunkDestination<'pkg> {
     /// form is `mod.config.json`, and that is not a byte-for-byte transform of
     /// it. Read it with [`Modpkg::load_metadata`] instead.
     Root(&'static str),
+
+    /// A hashtable chunk, written at `hashes/{file_name}`.
+    ///
+    /// The package stores it under `_meta_/hashes/`, and `hashes/` beside
+    /// the content is where a mod project keeps its tables - the same
+    /// agreement by which [`Root`](Self::Root)'s names are the ones a
+    /// project uses. `file_name` borrows from the package's own path table.
+    ///
+    /// Planned by where the chunk is stored, not by what the metadata
+    /// declares: like the plan itself, this answers "where would this chunk
+    /// land on disk" and never produces a table for lookup. The
+    /// manifest-gated read is [`Modpkg::load_hashtables`].
+    Hashtable {
+        /// The table's file name, e.g. `game.hashes.txt`.
+        file_name: &'pkg str,
+    },
 }
 
 impl ChunkDestination<'_> {
@@ -176,6 +210,7 @@ impl fmt::Display for ChunkDestination<'_> {
                 path,
             } => write!(f, "{layer}/{path}"),
             Self::Root(file_name) => f.write_str(file_name),
+            Self::Hashtable { file_name } => write!(f, "{HASHES_DIR_NAME}/{file_name}"),
         }
     }
 }
@@ -256,7 +291,10 @@ impl<TSource: Read + Seek> Modpkg<TSource> {
                     // of the plan rather than dumped under `_meta_/`.
                     None => match root_file_name(path) {
                         Some(file_name) => ChunkDestination::Root(file_name),
-                        None => continue,
+                        None => match hashtable_file_name(path) {
+                            Some(file_name) => ChunkDestination::Hashtable { file_name },
+                            None => continue,
+                        },
                     },
                 };
 
@@ -276,6 +314,30 @@ fn root_file_name(chunk_path: &str) -> Option<&'static str> {
         THUMBNAIL_CHUNK_PATH => Some("thumbnail.webp"),
         _ => None,
     }
+}
+
+/// The file name a `_meta_/hashes/` chunk lands under, if it is one.
+///
+/// The placement rule behind [`ChunkDestination::Hashtable`], public so a
+/// caller mapping a package's hashtable manifest to extracted files - as
+/// `ltk_mod_project`'s importer does - applies the same rule the plan does
+/// and the two cannot drift. `None` for a chunk path outside `_meta_/hashes/`
+/// or one with no usable file name; nothing is planned for those.
+///
+/// The escape-proofing for hashtable destinations lives here, at the seam,
+/// so every consumer of the plan inherits it: a tail that climbs, nests or
+/// re-roots lands by its file name rather than steering the write, and a tail
+/// with no file name plans nothing. The result is a subslice of `chunk_path`,
+/// so a plan's borrows survive.
+pub fn hashtable_file_name(chunk_path: &str) -> Option<&str> {
+    let tail = chunk_path
+        .strip_prefix(HASHTABLES_CHUNK_DIR)?
+        .strip_prefix('/')?;
+    let file_name = tail
+        .rsplit(['/', '\\'])
+        .next()
+        .expect("rsplit yields at least one part");
+    (!file_name.is_empty() && file_name != ".." && file_name != ".").then_some(file_name)
 }
 
 #[cfg(test)]
@@ -360,6 +422,59 @@ mod tests {
             paths(&three_layers_and_a_readme().extraction_plan()),
             ["aatrox/x.bin", "base/x.bin", "zed/x.bin", "README.md"]
         );
+    }
+
+    /// A hashtable chunk is stored under `_meta_/hashes/` but lands under
+    /// `hashes/` beside the content - its own destination, not `Root`.
+    #[test]
+    fn a_hashtable_chunk_lands_under_the_hashes_directory() {
+        let modpkg = package(|builder| {
+            builder
+                .with_chunk(chunk("x.bin"))
+                .with_hashtable(
+                    crate::ModpkgHashtable {
+                        path: "_meta_/hashes/game.hashes.txt".to_string(),
+                        category: ltk_hashtable::Category::Game,
+                        algorithm: ltk_hashtable::Algorithm::Xxh64,
+                        bits: 64,
+                    },
+                    "ASSETS/Custom/One.tex\n",
+                )
+                .unwrap()
+        });
+
+        let plan = modpkg.extraction_plan();
+
+        assert!(paths(&plan).contains(&"hashes/game.hashes.txt".to_string()));
+        // `Root` keeps its exact meaning: the readme, the license and the
+        // thumbnail. A table is not a root file.
+        assert!(paths(&plan.root_files()).is_empty());
+    }
+
+    /// The placement rule for `_meta_/hashes/` tails: a plain file name lands
+    /// under `hashes/`, and a tail that climbs, nests or re-roots lands by
+    /// its file name - so a hostile package cannot steer a write outside it.
+    #[test]
+    fn a_hashtable_tail_that_escapes_lands_by_its_file_name() {
+        assert_eq!(
+            hashtable_file_name("_meta_/hashes/game.hashes.txt"),
+            Some("game.hashes.txt")
+        );
+        assert_eq!(
+            hashtable_file_name("_meta_/hashes/../license"),
+            Some("license")
+        );
+        assert_eq!(
+            hashtable_file_name("_meta_/hashes/sub/dir.txt"),
+            Some("dir.txt")
+        );
+        assert_eq!(
+            hashtable_file_name("_meta_/hashes/evil\\name.txt"),
+            Some("name.txt")
+        );
+        assert_eq!(hashtable_file_name("_meta_/hashes/"), None);
+        assert_eq!(hashtable_file_name("_meta_/hashes/x/.."), None);
+        assert_eq!(hashtable_file_name("_meta_/license"), None);
     }
 
     /// The two halves the extractor writes, so that narrowing and extracting

--- a/crates/ltk_overlay/src/builder/metadata.rs
+++ b/crates/ltk_overlay/src/builder/metadata.rs
@@ -641,6 +641,7 @@ mod tests {
                 transformers: vec![],
                 layers: self.layers.clone(),
                 thumbnail: None,
+                hashtables: vec![],
             })
         }
 
@@ -747,6 +748,7 @@ mod tests {
                 transformers: vec![],
                 layers: self.layers.clone(),
                 thumbnail: None,
+                hashtables: vec![],
             })
         }
 

--- a/crates/ltk_overlay/src/content/tests.rs
+++ b/crates/ltk_overlay/src/content/tests.rs
@@ -21,6 +21,7 @@ fn create_test_mod_dir() -> tempfile::TempDir {
         transformers: vec![],
         layers: ltk_mod_project::ModProjectLayer::default_table(),
         thumbnail: None,
+        hashtables: vec![],
     };
     fs::write(
         mod_dir.join("mod.config.json"),

--- a/crates/ltk_overlay/src/fantome_content.rs
+++ b/crates/ltk_overlay/src/fantome_content.rs
@@ -240,6 +240,7 @@ impl<R: Read + Seek + Send + Sync> ModContentProvider for FantomeContent<R> {
             transformers: Vec::new(),
             layers,
             thumbnail: None,
+            hashtables: vec![],
         })
     }
 
@@ -530,6 +531,8 @@ mod tests {
             champions: Vec::new(),
             maps: Vec::new(),
             layers: std::collections::HashMap::new(),
+            hashtables: Vec::new(),
+            extra: Default::default(),
         })
         .unwrap()
     }
@@ -593,6 +596,8 @@ mod tests {
                 champions: Vec::new(),
                 maps: Vec::new(),
                 layers: std::collections::HashMap::new(),
+                hashtables: Vec::new(),
+                extra: Default::default(),
             })
             .unwrap()
         );

--- a/crates/ltk_overlay/src/modpkg_content.rs
+++ b/crates/ltk_overlay/src/modpkg_content.rs
@@ -77,6 +77,7 @@ impl<R: Read + Seek + Send + Sync> ModContentProvider for ModpkgContent<R> {
             transformers: Vec::new(),
             layers,
             thumbnail: None,
+            hashtables: vec![],
         })
     }
 

--- a/crates/ltk_overlay/src/strings.rs
+++ b/crates/ltk_overlay/src/strings.rs
@@ -377,6 +377,7 @@ mod tests {
                 transformers: vec![],
                 layers: self.layers.clone(),
                 thumbnail: None,
+                hashtables: vec![],
             })
         }
 

--- a/crates/ltk_overlay/tests/cross_wad_import.rs
+++ b/crates/ltk_overlay/tests/cross_wad_import.rs
@@ -79,6 +79,7 @@ fn write_mod_dir(root: &Utf8Path, name: &str, ahri_chunk_bytes: &[u8]) -> Utf8Pa
             string_overrides: Default::default(),
         }],
         thumbnail: None,
+        hashtables: vec![],
     };
     fs::write(
         mod_dir.join("mod.config.json").as_std_path(),

--- a/crates/ltk_overlay/tests/localized_wad_routing.rs
+++ b/crates/ltk_overlay/tests/localized_wad_routing.rs
@@ -81,6 +81,7 @@ fn write_mod_dir(
             string_overrides: Default::default(),
         }],
         thumbnail: None,
+        hashtables: vec![],
     };
     fs::write(
         mod_dir.join("mod.config.json").as_std_path(),

--- a/crates/ltk_overlay/tests/rebuild.rs
+++ b/crates/ltk_overlay/tests/rebuild.rs
@@ -64,6 +64,7 @@ fn write_mod_dir(root: &Utf8Path, name: &str, override_bytes: &[u8]) -> Utf8Path
             string_overrides: Default::default(),
         }],
         thumbnail: None,
+        hashtables: vec![],
     };
     fs::write(
         mod_dir.join("mod.config.json").as_std_path(),

--- a/crates/ltk_overlay/tests/string_overrides.rs
+++ b/crates/ltk_overlay/tests/string_overrides.rs
@@ -114,6 +114,7 @@ fn write_mod_dir(root: &Utf8Path, name: &str, layers: Vec<ModProjectLayer>) -> U
         transformers: vec![],
         layers,
         thumbnail: None,
+        hashtables: vec![],
     };
     fs::write(
         mod_dir.join("mod.config.json").as_std_path(),

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,11 @@ publish = false
 changelog_update = true
 
 [[package]]
+name = "ltk_hashtable"
+publish = true
+changelog_update = true
+
+[[package]]
 name = "ltk_fantome"
 publish = true
 changelog_update = true


### PR DESCRIPTION
## Summary

Mod archives can now embed the hashtables their custom content needs (closes #200).

- New `ltk_hashtable` crate: parsing, categories/algorithms (unknown ones round-trip verbatim), key computation, and collision detection for `.hashes.txt` tables.
- Projects declare tables in the manifest (`hashtables` in `mod.config.json`) - manifest-declared only, no filename discovery.
- `.modpkg` packs them as `_meta_/hashes/` chunks the metadata declares (schema version 3); `game` names the package's own chunk table already recovers are trimmed and the count reported. Fantome archives carry them as `META/hashes/` entries.
- Import round-trips tables back to `hashes/` with the manifest entries pointing at them.
- Chunk paths keep their authored casing; case-variant declarations of one chunk are refused instead of silently shipping one file's bytes under both.
- Two different table files landing on one flattened destination name fail the pack and the import (`DuplicateHashtableName`) rather than being silently renamed.
- Escape hatch, packing side: a WAD-root file named as a bare hex path hash packs under the raw hash.

## Test plan

- `cargo test --workspace --all-features` green on Windows and Linux.
- clippy, fmt, and `cargo doc` clean.