### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1429,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "ltk_overlay"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "byteorder",
  "camino",

--- a/crates/ltk_overlay/CHANGELOG.md
+++ b/crates/ltk_overlay/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.9.1](https://github.com/LeagueToolkit/league-mod/compare/ltk_overlay-v0.9.0...ltk_overlay-v0.9.1) - 2026-08-29
+
+### Added
+
+- *(bench)* report peak commit and peak working set
+- *(overlay)* stream override reads through a per-chunk visitor
+- *(bench)* benchmark several .fantome mods at once
+- *(bench)* benchmark a .fantome archive, packed or exploded
+
+### Fixed
+
+- overlay bench harness timer
+
+### Other
+
+- *(overlay)* compress overrides in bounded batches, deduped before reading
+- *(overlay)* mount packed fantome WADs lazily
+
 ## [0.9.0](https://github.com/LeagueToolkit/league-mod/compare/ltk_overlay-v0.8.0...ltk_overlay-v0.9.0) - 2026-08-28
 
 ### Added

--- a/crates/ltk_overlay/Cargo.toml
+++ b/crates/ltk_overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ltk_overlay"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "WAD overlay/profile builder for League of Legends mods"


### PR DESCRIPTION



## 🤖 New release

* `league-mod`: 0.2.1
* `ltk_overlay`: 0.9.0 -> 0.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `league-mod`

<blockquote>

## [0.2.1](https://github.com/LeagueToolkit/league-mod/releases/tag/league-mod-v0.2.1) - 2025-11-21

### Added

- update version handling in metadata to use semver::Version
- add layers to metadata
- better meta handling
- use metadata chunk
- add support for signing mod packages (argument only)
- add check for update
- add color styling to clap output
- improve cli command and use miette
- add initial winget stuff
- add support for packing to fantome
- add option to specify thumbnail in mod project config

### Fixed

- minor clone stuff
- convert version to string format for consistent display in info_mod_package
- pack readme and thumbnail into modpkg
- fmt
- pad println output
- skip base layer conditionally
- layer presence lookup
- base skip
- error if explicit base layer
- typo

### Other

- *(league-mod)* bump version to v0.2.1
- *(league-mod)* release v0.2.0
- update release-plz configuration and add changelogs for new crates
- release
- include schema version when building metadata
- mark 'sign' field as dead code in PackModProjectArgs
- release
- bump version to 0.2.0
- add quick install instructions for league-mod using PowerShell
- bump league-mod version to 0.1.1
- prepare repo for crates releases
- remove comments
- fix checks
- fix deny licenses
- add ci workflow
- add release-plz
- add readme
- move existing mod crates
</blockquote>

## `ltk_overlay`

<blockquote>

## [0.9.1](https://github.com/LeagueToolkit/league-mod/compare/ltk_overlay-v0.9.0...ltk_overlay-v0.9.1) - 2026-08-29

### Added

- *(bench)* report peak commit and peak working set
- *(overlay)* stream override reads through a per-chunk visitor
- *(bench)* benchmark several .fantome mods at once
- *(bench)* benchmark a .fantome archive, packed or exploded

### Fixed

- overlay bench harness timer

### Other

- *(overlay)* compress overrides in bounded batches, deduped before reading
- *(overlay)* mount packed fantome WADs lazily
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).