### PR TITLE
feat(fantome): mount packed WADs in place

### DIFF
--- a/crates/ltk_fantome/src/lib.rs
+++ b/crates/ltk_fantome/src/lib.rs
@@ -11,6 +11,11 @@
 //! WADs stored so a reader can seek to them. Both raw-copy everything they do
 //! not themselves replace, and both belong to an importer working on a copy it
 //! owns.
+//!
+//! What normalizing buys is spent by
+//! [`FantomeReader::mount_packed_wad`]: a packed WAD an archive stores is read
+//! chunk by chunk where it lies, so looking inside one costs its TOC and the
+//! chunks asked for rather than the whole archive unpacked to a directory.
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -18,19 +23,24 @@ use std::collections::HashMap;
 
 pub mod error;
 mod normalize;
+mod packed;
 mod reader;
 mod rewrite;
 mod writer;
 
 pub use error::{FantomeExtractError, FantomeWriteError};
-/// Re-exported because [`WadExtractOptions`] names them: a caller names chunks
-/// by implementing [`PathResolver`] over whatever it holds, or leaves the
-/// default [`NoResolver`] in place and leaves the naming to the archive's own
-/// bins. [`NamingPolicy`] decides what becomes of a chunk two paths claim.
-pub use ltk_wad::{NamingPolicy, NoResolver, PathResolver};
+/// Re-exported because this crate's own signatures name them.
+///
+/// [`WadExtractOptions`] takes the first three: a caller names chunks by
+/// implementing [`PathResolver`] over whatever it holds, or leaves the default
+/// [`NoResolver`] in place and leaves the naming to the archive's own bins,
+/// and [`NamingPolicy`] decides what becomes of a chunk two paths claim.
+/// [`Wad`] is what [`FantomeReader::mount_packed_wad`] answers with.
+pub use ltk_wad::{NamingPolicy, NoResolver, PathResolver, Wad};
 pub use normalize::{
     FantomeNormalizeError, NormalizeOutcome, normalize_archive, store_packed_wads,
 };
+pub use packed::PackedWadSource;
 pub use reader::{FantomeEntry, FantomeReader, WadExtractOptions, WadProgress, classify_entry};
 pub use rewrite::{FantomeRewriteError, RewriteOutcome, add_hashtables, replace_entries};
 pub use writer::FantomeWriter;

--- a/crates/ltk_fantome/src/packed.rs
+++ b/crates/ltk_fantome/src/packed.rs
@@ -1,0 +1,184 @@
+//! [`PackedWadSource`]: read a packed WAD where the archive keeps it.
+//!
+//! A packed WAD is one archive entry holding a whole WAD. Reading a few chunks
+//! out of one needs none of the entry's other bytes: the WAD's TOC names each
+//! chunk's offset, so a source that can seek reaches them directly. A stored
+//! entry allows that and a deflated one does not - deflate has no random
+//! access, so a deflated entry must be inflated whole before any of it can be
+//! addressed at all.
+//!
+//! [`normalize_archive`](crate::normalize_archive) is what makes an archive's
+//! packed WADs stored; this is what spends that. An archive nobody normalized
+//! still reads, at the cost of holding its WAD in memory.
+
+use std::fmt;
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+
+use zip::read::ZipFileSeek;
+use zip::{CompressionMethod, ZipArchive};
+
+use crate::error::FantomeExtractError;
+use crate::reader::read_entry;
+
+/// A packed WAD's bytes, addressed from the WAD's own first byte.
+///
+/// Mount it with [`Wad::mount`](ltk_wad::Wad::mount) - which is what
+/// [`FantomeReader::mount_packed_wad`](crate::FantomeReader::mount_packed_wad)
+/// does - and the WAD's offsets land on the WAD's own bytes, whatever the
+/// archive around it holds.
+///
+/// [`is_in_place`](Self::is_in_place) reports which of the two ways it got
+/// them, since that is the difference between reading a chunk and inflating a
+/// gigabyte to reach it.
+pub struct PackedWadSource<'a, R> {
+    inner: Inner<'a, R>,
+}
+
+/// Where a mounted WAD's bytes come from.
+///
+/// The two arms are what makes the seam real: an archive this crate normalized
+/// takes the first, and one shipped by another tool takes the second without
+/// the caller writing a second code path.
+enum Inner<'a, R> {
+    /// The entry read where the archive stores it, seek by seek.
+    ///
+    /// Boxed because the entry reader carries a copy of the archive's record
+    /// for it, which is several times the size of the other arm and would
+    /// otherwise be what every mounted WAD costs to move.
+    InPlace {
+        entry: Box<ZipFileSeek<'a, R>>,
+        /// Position within the WAD.
+        ///
+        /// Tracked here because [`ZipFileSeek`]'s own [`Seek`] answers with the
+        /// offset reached in the outer archive rather than in the entry, which
+        /// is not the number the [`Seek`] contract asks for. Every seek below
+        /// is absolute for the same reason: a relative one would be resolved
+        /// against a position this type never reads back.
+        pos: u64,
+        /// Length of the entry, which the entry reader clamps reads and seeks
+        /// to.
+        len: u64,
+    },
+    /// The entry inflated into memory, which a deflated archive costs in full
+    /// however few of the WAD's chunks the caller goes on to read.
+    Buffered(Cursor<Vec<u8>>),
+}
+
+impl<'a, R: Read + Seek> PackedWadSource<'a, R> {
+    /// The bytes of the entry at `index`, read in place when it is stored.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the entry's header cannot be read, or when a deflated entry
+    /// cannot be inflated.
+    pub(crate) fn at_index(
+        archive: &'a mut ZipArchive<R>,
+        index: usize,
+    ) -> Result<Self, FantomeExtractError> {
+        let entry = archive.by_index_raw(index)?;
+        let stored = entry.compression() == CompressionMethod::Stored;
+        // The entry reader clamps to the compressed size, so that is the length
+        // the position arithmetic here has to agree with. For a stored entry it
+        // is the uncompressed size too, unless the archive says otherwise - and
+        // an archive that says otherwise is one to follow rather than correct.
+        let len = entry.compressed_size();
+        drop(entry);
+
+        let inner = if stored {
+            Inner::InPlace {
+                entry: Box::new(archive.by_index_seek(index)?),
+                pos: 0,
+                len,
+            }
+        } else {
+            Inner::Buffered(Cursor::new(read_entry(&mut archive.by_index(index)?)?))
+        };
+
+        Ok(Self { inner })
+    }
+}
+
+impl<R> PackedWadSource<'_, R> {
+    /// Whether the WAD is read where the archive stores it.
+    ///
+    /// `false` means the entry was deflated and had to be inflated into memory
+    /// first, which is the cost [`normalize_archive`](crate::normalize_archive)
+    /// exists to remove.
+    pub fn is_in_place(&self) -> bool {
+        matches!(self.inner, Inner::InPlace { .. })
+    }
+
+    /// Length of the WAD in bytes.
+    fn len(&self) -> u64 {
+        match &self.inner {
+            Inner::InPlace { len, .. } => *len,
+            Inner::Buffered(cursor) => cursor.get_ref().len() as u64,
+        }
+    }
+
+    /// Position within the WAD.
+    fn position(&self) -> u64 {
+        match &self.inner {
+            Inner::InPlace { pos, .. } => *pos,
+            Inner::Buffered(cursor) => cursor.position(),
+        }
+    }
+}
+
+impl<R> fmt::Debug for PackedWadSource<'_, R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PackedWadSource")
+            .field("in_place", &self.is_in_place())
+            .field("len", &self.len())
+            .field("position", &self.position())
+            .finish()
+    }
+}
+
+impl<R: Read + Seek> Read for PackedWadSource<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match &mut self.inner {
+            Inner::InPlace { entry, pos, .. } => {
+                let read = entry.read(buf)?;
+                *pos += read as u64;
+                Ok(read)
+            }
+            Inner::Buffered(cursor) => cursor.read(buf),
+        }
+    }
+}
+
+impl<R: Read + Seek> Seek for PackedWadSource<'_, R> {
+    /// Seek within the WAD, counting from its own first byte.
+    ///
+    /// A seek past the end lands on the end rather than past it, in both arms:
+    /// the entry reader clamps, and the buffered arm is held to the same answer
+    /// so that which arm a caller got cannot change what it reads back.
+    fn seek(&mut self, from: SeekFrom) -> io::Result<u64> {
+        let target = match from {
+            SeekFrom::Start(offset) => Some(offset),
+            SeekFrom::End(delta) => self.len().checked_add_signed(delta),
+            SeekFrom::Current(delta) => self.position().checked_add_signed(delta),
+        }
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "seek to a negative or overflowing position",
+            )
+        })?
+        .min(self.len());
+
+        match &mut self.inner {
+            Inner::InPlace { entry, pos, .. } => {
+                entry.seek(SeekFrom::Start(target))?;
+                *pos = target;
+            }
+            Inner::Buffered(cursor) => cursor.set_position(target),
+        }
+
+        Ok(target)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ltk_fantome/src/packed/tests.rs
+++ b/crates/ltk_fantome/src/packed/tests.rs
@@ -1,0 +1,183 @@
+use super::*;
+
+use std::io::Write;
+
+use zip::ZipWriter;
+use zip::write::SimpleFileOptions;
+
+use crate::FantomeReader;
+
+const WAD_ENTRY: &str = "WAD/Aatrox.wad.client";
+const WAD_NAME: &str = "Aatrox.wad.client";
+const PAYLOAD: &[u8] = b"the chunk payload, stored uncompressed";
+
+/// A packed WAD holding one stored chunk under `packed/file.bin`.
+fn packed_wad_bytes() -> Vec<u8> {
+    use ltk_wad::{WadBuilder, WadChunkBuilder, WadChunkCompression};
+
+    let mut cursor = Cursor::new(Vec::new());
+    WadBuilder::default()
+        .with_chunk(
+            WadChunkBuilder::default()
+                .with_path("packed/file.bin")
+                .with_force_compression(WadChunkCompression::None),
+        )
+        .build_to_writer(&mut cursor, |_hash, writer| {
+            writer.write_all(PAYLOAD)?;
+            Ok(())
+        })
+        .unwrap();
+    cursor.into_inner()
+}
+
+/// An archive whose packed WAD is held under `wads`, behind a deflated entry.
+///
+/// The leading entry is what makes these tests worth running: it pushes the WAD
+/// off offset zero, so a source reporting the outer archive's offsets and one
+/// reporting the WAD's own no longer agree.
+fn archive(wads: CompressionMethod) -> FantomeReader<Cursor<Vec<u8>>> {
+    let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("META/info.json", deflated).unwrap();
+    zip.write_all(br#"{"Name":"Mod","Author":"A","Version":"1","Description":"d"}"#)
+        .unwrap();
+    zip.start_file(WAD_ENTRY, deflated.compression_method(wads))
+        .unwrap();
+    zip.write_all(&packed_wad_bytes()).unwrap();
+
+    FantomeReader::new(Cursor::new(zip.finish().unwrap().into_inner())).unwrap()
+}
+
+/// The chunk `packed/file.bin`, read back through a mounted WAD.
+fn read_the_chunk(reader: &mut FantomeReader<Cursor<Vec<u8>>>) -> Vec<u8> {
+    let mut wad = reader.mount_packed_wad(WAD_NAME).unwrap().unwrap();
+    let chunk = *wad.chunks().iter().next().unwrap();
+    wad.load_chunk_decompressed(&chunk).unwrap().to_vec()
+}
+
+/// A stored entry is what normalization produces, and reading it is the point
+/// of producing it: the WAD's own offsets land on its own bytes with nothing
+/// inflated on the way.
+#[test]
+fn a_stored_packed_wad_is_read_where_the_archive_keeps_it() {
+    let mut reader = archive(CompressionMethod::Stored);
+
+    assert!(
+        reader
+            .packed_wad_source(WAD_NAME)
+            .unwrap()
+            .unwrap()
+            .is_in_place(),
+        "a stored entry should be read in place"
+    );
+    assert_eq!(read_the_chunk(&mut reader), PAYLOAD);
+}
+
+/// Deflate has no random access, so an archive nobody normalized still has to
+/// be inflated whole. It must read back the same chunk regardless: which arm a
+/// caller gets changes the cost and nothing else.
+#[test]
+fn a_deflated_packed_wad_is_inflated_and_reads_the_same() {
+    let mut reader = archive(CompressionMethod::Deflated);
+
+    assert!(
+        !reader
+            .packed_wad_source(WAD_NAME)
+            .unwrap()
+            .unwrap()
+            .is_in_place(),
+        "a deflated entry cannot be read in place"
+    );
+    assert_eq!(read_the_chunk(&mut reader), PAYLOAD);
+}
+
+/// A WAD shipped as a directory of loose files has no packed entry, and a name
+/// the archive does not hold at all has none either. Neither is an error.
+#[test]
+fn a_wad_the_archive_holds_no_packed_copy_of_mounts_to_none() {
+    let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
+    zip.start_file(
+        "WAD/Ahri.wad.client/data/loose.bin",
+        SimpleFileOptions::default(),
+    )
+    .unwrap();
+    zip.write_all(b"a loose file").unwrap();
+    let bytes = zip.finish().unwrap().into_inner();
+
+    let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+    assert!(
+        reader
+            .mount_packed_wad("Ahri.wad.client")
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        reader
+            .mount_packed_wad("Absent.wad.client")
+            .unwrap()
+            .is_none()
+    );
+}
+
+/// The entry reader underneath answers a seek with the offset it reached in the
+/// outer archive, which is not the number [`Seek`] asks for. A WAD's TOC holds
+/// offsets from the WAD's own first byte, so a source reporting the archive's
+/// would put every chunk read past where that chunk is.
+#[test]
+fn seeking_counts_from_the_wads_own_first_byte() {
+    let wad_bytes = packed_wad_bytes();
+    let end = wad_bytes.len() as u64;
+    let mut reader = archive(CompressionMethod::Stored);
+    let mut source = reader.packed_wad_source(WAD_NAME).unwrap().unwrap();
+
+    assert_eq!(source.seek(SeekFrom::Start(0)).unwrap(), 0);
+    assert_eq!(source.stream_position().unwrap(), 0);
+    assert_eq!(source.seek(SeekFrom::Start(4)).unwrap(), 4);
+    assert_eq!(source.seek(SeekFrom::Current(2)).unwrap(), 6);
+    assert_eq!(source.seek(SeekFrom::End(0)).unwrap(), end);
+
+    // Past the end lands on the end, and reads nothing rather than reading on
+    // into whatever the archive keeps after the entry.
+    assert_eq!(source.seek(SeekFrom::Start(end + 4096)).unwrap(), end);
+    assert_eq!(source.read(&mut [0u8; 16]).unwrap(), 0);
+
+    // And the bytes at an offset are the WAD's bytes at that offset.
+    source.seek(SeekFrom::Start(0)).unwrap();
+    let mut magic = [0u8; 2];
+    source.read_exact(&mut magic).unwrap();
+    assert_eq!(&magic, &wad_bytes[..2]);
+}
+
+/// Both arms answer a seek past the end with the end, so a caller cannot tell
+/// which one it got from the positions it reads back.
+#[test]
+fn both_arms_report_the_same_positions() {
+    let end = packed_wad_bytes().len() as u64;
+
+    for method in [CompressionMethod::Stored, CompressionMethod::Deflated] {
+        let mut reader = archive(method);
+        let mut source = reader.packed_wad_source(WAD_NAME).unwrap().unwrap();
+
+        assert_eq!(source.seek(SeekFrom::End(0)).unwrap(), end, "{method:?}");
+        assert_eq!(
+            source.seek(SeekFrom::Start(end + 4096)).unwrap(),
+            end,
+            "{method:?}"
+        );
+        assert_eq!(source.seek(SeekFrom::Start(7)).unwrap(), 7, "{method:?}");
+        assert_eq!(source.stream_position().unwrap(), 7, "{method:?}");
+    }
+}
+
+/// A negative seek is refused rather than wrapping into a far offset.
+#[test]
+fn a_seek_before_the_start_is_refused() {
+    for method in [CompressionMethod::Stored, CompressionMethod::Deflated] {
+        let mut reader = archive(method);
+        let mut source = reader.packed_wad_source(WAD_NAME).unwrap().unwrap();
+
+        let refused = source.seek(SeekFrom::Current(-1)).unwrap_err();
+        assert_eq!(refused.kind(), io::ErrorKind::InvalidInput, "{method:?}");
+    }
+}

--- a/crates/ltk_fantome/src/reader.rs
+++ b/crates/ltk_fantome/src/reader.rs
@@ -15,6 +15,7 @@ use zip::read::ZipFile;
 
 use crate::FantomeInfo;
 use crate::error::FantomeExtractError;
+use crate::packed::PackedWadSource;
 
 /// Reads a Fantome archive entry by entry.
 pub struct FantomeReader<R: Read + Seek> {
@@ -164,7 +165,7 @@ pub(crate) fn copy_entry(entry: &mut ZipFile<'_>, sink: &mut impl io::Write) -> 
 ///
 /// The buffer grows as the copy runs rather than being sized from the entry's
 /// header, so a declared length nothing backs cannot ask for the allocation.
-fn read_entry(entry: &mut ZipFile<'_>) -> io::Result<Vec<u8>> {
+pub(crate) fn read_entry(entry: &mut ZipFile<'_>) -> io::Result<Vec<u8>> {
     let mut bytes = Vec::new();
     copy_entry(entry, &mut bytes)?;
     Ok(bytes)
@@ -288,18 +289,77 @@ impl<R: Read + Seek> FantomeReader<R> {
         &mut self,
         wad_name: &str,
     ) -> Result<Option<Vec<u8>>, FantomeExtractError> {
-        let index = (0..self.archive.len()).find(|i| {
-            self.archive.by_index(*i).is_ok_and(|file| {
-                matches!(
-                    classify_entry(file.name()),
-                    Some(FantomeEntry::PackedWad(name)) if name.eq_ignore_ascii_case(wad_name)
-                )
-            })
-        });
-        let Some(index) = index else {
+        let Some(index) = self.packed_wad_index(wad_name) else {
             return Ok(None);
         };
         Ok(Some(read_entry(&mut self.archive.by_index(index)?)?))
+    }
+
+    /// Mount the packed WAD stored as the single entry `WAD/{wad_name}`, or
+    /// `None` when the archive holds no such entry.
+    ///
+    /// Reading a WAD costs its TOC and the chunks actually asked for, not the
+    /// whole entry, whenever the archive stores that entry - which is what
+    /// [`normalize_archive`](crate::normalize_archive) arranges and
+    /// [`PackedWadSource::is_in_place`] reports. A deflated entry is inflated
+    /// into memory first, because deflate cannot be seeked into; the mounted
+    /// WAD then behaves the same and only the cost differs.
+    ///
+    /// The name is matched case-insensitively, like every entry lookup here,
+    /// and a WAD stored as a directory of files answers `None` on the same
+    /// terms as [`read_packed_wad`](Self::read_packed_wad). The mounted WAD
+    /// borrows the reader, so read whatever else is wanted from the archive
+    /// before mounting or after dropping it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry cannot be read, or if its bytes are not a
+    /// WAD the mount understands.
+    pub fn mount_packed_wad(
+        &mut self,
+        wad_name: &str,
+    ) -> Result<Option<Wad<PackedWadSource<'_, R>>>, FantomeExtractError> {
+        match self.packed_wad_source(wad_name)? {
+            Some(source) => Ok(Some(Wad::mount(source)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// The bytes of the packed WAD `wad_name`, without mounting them.
+    ///
+    /// What [`mount_packed_wad`](Self::mount_packed_wad) is built on, for a
+    /// caller that wants to know what the read will cost - see
+    /// [`PackedWadSource::is_in_place`] - or to do something with the bytes
+    /// other than mount them. Mounting consumes the source, so a caller that
+    /// wants both asks here first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the entry cannot be read.
+    pub fn packed_wad_source(
+        &mut self,
+        wad_name: &str,
+    ) -> Result<Option<PackedWadSource<'_, R>>, FantomeExtractError> {
+        let Some(index) = self.packed_wad_index(wad_name) else {
+            return Ok(None);
+        };
+        PackedWadSource::at_index(&mut self.archive, index).map(Some)
+    }
+
+    /// The index of the entry holding the packed WAD `wad_name`.
+    ///
+    /// Only entry names are read, so a lookup that finds nothing costs no
+    /// decompression. The name is resolved back to an index through the
+    /// archive's own table rather than by counting the iteration, so nothing
+    /// here rests on that iteration being in index order.
+    fn packed_wad_index(&self, wad_name: &str) -> Option<usize> {
+        let entry = self.archive.file_names().find(|name| {
+            matches!(
+                classify_entry(name),
+                Some(FantomeEntry::PackedWad(packed)) if packed.eq_ignore_ascii_case(wad_name)
+            )
+        })?;
+        self.archive.index_for_name(entry)
     }
 
     /// How many entries the archive holds, directory records included.


### PR DESCRIPTION
Adds `FantomeReader::mount_packed_wad` and `packed_wad_source`: a packed WAD held as a stored entry is read chunk by chunk where the archive keeps it, so looking inside one costs its TOC and the chunks asked for rather than the whole archive unpacked to a directory.

This is what `normalize_archive` was buying. It unblocks ltk-manager's archive-storage health check, which today unpacks 1.35 GB per mod purely to read bins.

No mmap: `FantomeReader<R>` is already generic over `Read + Seek`, so a clamped region view gives the same no-inflation property with no `unsafe`, no archive path and no new dependency. `ltk_overlay::fantome_content` carries a private mmap-based copy of this mechanism that can be deleted onto it later.

`PackedWadSource` wraps the zip crate's seekable entry reader rather than using it directly: `ZipFileSeek`'s `Seek` impl answers with the offset reached in the outer archive, not within the entry. Nothing in `Wad::mount` or `load_chunk_*` reads a seek's return value, so it is latent rather than an active bug, but a `BufReader` over it or any relative seek would land wrong, and a WAD's TOC is all offsets from the WAD's own first byte. The wrapper tracks its own position and always issues absolute seeks.

A deflated entry still reads, inflated once, and both arms answer seeks identically so a caller cannot tell which it got from positions alone - only from `is_in_place()`.

6 new tests; 66 pass in `ltk_fantome`. Workspace `fmt`, `clippy --all-targets`, `doc --no-deps` and `test` clean.