### PR TITLE
fix(fantome): write a replaced packed WAD stored, not deflated

### DIFF
--- a/crates/ltk_fantome/src/tests.rs
+++ b/crates/ltk_fantome/src/tests.rs
@@ -346,6 +346,120 @@ mod rewrite {
         assert_eq!(extracted, b"repaired bytes");
     }
 
+    /// A packed WAD holding one stored chunk, as bytes for a zip entry.
+    fn packed_wad_bytes(payload: &[u8]) -> Vec<u8> {
+        use ltk_wad::{WadBuilder, WadChunkBuilder, WadChunkCompression};
+
+        let payload = payload.to_vec();
+        let mut cursor = Cursor::new(Vec::new());
+        WadBuilder::default()
+            .with_chunk(
+                WadChunkBuilder::default()
+                    .with_path("data/x.bin")
+                    .with_force_compression(WadChunkCompression::None),
+            )
+            .build_to_writer(&mut cursor, move |_hash, writer| {
+                std::io::Write::write_all(writer, &payload)?;
+                Ok(())
+            })
+            .unwrap();
+        cursor.into_inner()
+    }
+
+    /// A normalized archive: metadata deflated, its packed WAD stored.
+    fn archive_with_stored_wad(wad: &[u8]) -> Vec<u8> {
+        use zip::write::SimpleFileOptions;
+        use zip::{CompressionMethod, ZipWriter};
+
+        let mut zip = ZipWriter::new(Cursor::new(Vec::new()));
+        let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        zip.start_file("META/info.json", deflated).unwrap();
+        std::io::Write::write_all(
+            &mut zip,
+            br#"{"Name":"Mod","Author":"A","Version":"1","Description":"d"}"#,
+        )
+        .unwrap();
+        zip.start_file(
+            "WAD/Aatrox.wad.client",
+            deflated.compression_method(CompressionMethod::Stored),
+        )
+        .unwrap();
+        std::io::Write::write_all(&mut zip, wad).unwrap();
+        zip.finish().unwrap().into_inner()
+    }
+
+    /// Story: a repaired packed WAD goes back into the archive still seekable.
+    ///
+    /// Deflating it would undo exactly what [`normalize_archive`] bought - a
+    /// reader would have to inflate the whole entry to reach any chunk in it -
+    /// and would spend a minute of CPU on a large map mod to do it.
+    ///
+    /// [`normalize_archive`]: crate::normalize_archive
+    #[test]
+    fn a_replaced_packed_wad_stays_stored() {
+        let replacement = packed_wad_bytes(b"repaired chunk payload");
+        let bytes = archive_with_stored_wad(&packed_wad_bytes(b"stale chunk payload"));
+
+        let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+        let mut sink = Cursor::new(Vec::new());
+        crate::replace_entries(
+            &mut reader,
+            &mut sink,
+            &[("WAD/Aatrox.wad.client", replacement.as_slice())],
+            &[],
+        )
+        .unwrap();
+
+        let rewritten = sink.into_inner();
+        let mut out = FantomeReader::new(Cursor::new(rewritten)).unwrap();
+        assert!(
+            out.packed_wad_source("Aatrox.wad.client")
+                .unwrap()
+                .unwrap()
+                .is_in_place(),
+            "the replaced WAD was not written stored"
+        );
+
+        // And the bytes that come back are the replacement's, not the stale
+        // ones the archive held.
+        let mut wad = out.mount_packed_wad("Aatrox.wad.client").unwrap().unwrap();
+        let chunk = *wad.chunks().iter().next().unwrap();
+        assert_eq!(
+            &*wad.load_chunk_decompressed(&chunk).unwrap(),
+            b"repaired chunk payload"
+        );
+    }
+
+    /// Everything that is not a packed WAD stays deflated, which is what the
+    /// archive holds every loose file, table and metadata entry as.
+    #[test]
+    fn a_replaced_loose_entry_stays_deflated() {
+        use zip::CompressionMethod;
+
+        const CHANGED: &str = "WAD/Aatrox.wad.client/data/x.bin";
+
+        let bytes = archive_with_wrong_crc(&FantomeInfo::default(), b"payload");
+        let mut reader = FantomeReader::new(Cursor::new(bytes)).unwrap();
+        let mut sink = Cursor::new(Vec::new());
+        crate::replace_entries(
+            &mut reader,
+            &mut sink,
+            &[(
+                CHANGED,
+                b"a replacement long enough to be worth deflating".as_slice(),
+            )],
+            &[],
+        )
+        .unwrap();
+
+        let mut out = zip::ZipArchive::new(Cursor::new(sink.into_inner())).unwrap();
+        let index = out.index_for_name(CHANGED).expect("the replaced entry");
+        assert_eq!(
+            out.by_index_raw(index).unwrap().compression(),
+            CompressionMethod::Deflated
+        );
+    }
+
     /// An entry given but not held is added, so a caller does not have to know
     /// which of the two it is doing.
     #[test]

--- a/crates/ltk_fantome/src/writer.rs
+++ b/crates/ltk_fantome/src/writer.rs
@@ -1,16 +1,24 @@
 //! [`FantomeWriter`]: writes the entries of a Fantome archive.
 //!
-//! The writer owns the archive flavor (a Deflate-compressed zip) and the
-//! entry naming conventions (`WAD/`, `META/`). It does not know what a mod
-//! project is: deciding which files go into the archive is the caller's job
-//! (see `ltk_mod_project`'s `fantome` module).
+//! The writer owns the archive flavor and the entry naming conventions
+//! (`WAD/`, `META/`). It does not know what a mod project is: deciding which
+//! files go into the archive is the caller's job (see `ltk_mod_project`'s
+//! `fantome` module).
+//!
+//! The flavor is a Deflate-compressed zip with one exception: a **packed WAD
+//! is stored**. A reader seeks into a stored entry to reach one chunk and has
+//! to inflate a deflated one whole, so deflating a packed WAD costs a map mod
+//! a minute of CPU to produce an archive nothing can read cheaply. That is the
+//! same rule [`store_packed_wads`](crate::store_packed_wads) normalizes an
+//! archive to, and the writer holds to it so that a rewrite passing a WAD
+//! through cannot quietly undo it.
 
 use std::io::{Read, Seek, Write};
 
-use zip::ZipWriter;
 use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
 
-use crate::{FantomeHashtable, FantomeInfo};
+use crate::{FantomeEntry, FantomeHashtable, FantomeInfo, classify_entry};
 
 /// Failure to write a Fantome archive entry.
 #[derive(Debug, thiserror::Error)]
@@ -40,7 +48,14 @@ pub struct FantomeWriter<W: Write + Seek> {
 
 impl<W: Write + Seek> FantomeWriter<W> {
     /// Create a writer producing the standard Fantome flavor: a zip archive
-    /// with Deflate compression.
+    /// with Deflate compression, its packed WADs stored.
+    ///
+    /// A reader seeks into a stored entry to reach one chunk of a WAD and has
+    /// to inflate a deflated one whole, so a packed WAD is written stored
+    /// however it arrived - which is what [`store_packed_wads`] normalizes an
+    /// archive to, held to here so a rewrite cannot undo it.
+    ///
+    /// [`store_packed_wads`]: crate::store_packed_wads
     pub fn new(writer: W) -> Self {
         Self {
             zip: ZipWriter::new(writer),
@@ -135,8 +150,24 @@ impl<W: Write + Seek> FantomeWriter<W> {
         entry_path: &str,
         content: &mut impl Read,
     ) -> Result<(), FantomeWriteError> {
-        self.zip.start_file(entry_path, self.options)?;
+        self.zip
+            .start_file(entry_path, self.options_for(entry_path))?;
         std::io::copy(content, &mut self.zip)?;
         Ok(())
+    }
+
+    /// How the entry at `entry_path` is compressed.
+    ///
+    /// Read off the path rather than taken from the caller: whether an entry
+    /// is a packed WAD is the only thing the answer depends on, and a caller
+    /// asked to state it each time is a caller that can get it wrong. See the
+    /// [module docs](self) for what deflating a packed WAD costs.
+    fn options_for(&self, entry_path: &str) -> SimpleFileOptions {
+        match classify_entry(entry_path) {
+            Some(FantomeEntry::PackedWad(_)) => {
+                self.options.compression_method(CompressionMethod::Stored)
+            }
+            _ => self.options,
+        }
     }
 }


### PR DESCRIPTION
`FantomeWriter` set Deflated for every entry, so `replace_entries` deflated a packed WAD it was handed - undoing exactly what `normalize_archive` buys. A reader seeks into a stored entry to reach one chunk of a WAD and has to inflate a deflated one whole, so on a large map mod that is a minute of CPU spent to produce an archive nothing can read cheaply.

This blocks repairing bins inside a packed WAD, which is the point of the in-place work: the repaired WAD has to go back into the archive still seekable.

The compression is read off the entry path rather than added as a parameter. Whether an entry is a packed WAD is the only thing the answer depends on, and a caller asked to state it on every call is a caller that can state it wrong. It is also the rule `store_packed_wads` already normalizes an archive to, so the writer and the normalizer now agree by construction instead of by convention.

Nothing else changes: a packed WAD is the only entry that moves, and no public method other than `replace_entries` can produce one - `write_wad_entry` always writes `WAD/{name}/{rel}`, which classifies as a loose WAD file. Entries an `add_hashtables` rewrite merely passes through are raw-copied and keep whatever compression they arrived with, as before.

Two tests: a replaced packed WAD comes back `Stored` and mounts in place with the replacement's bytes, and a replaced loose entry stays `Deflated`. 68 pass in `ltk_fantome`; workspace `fmt`, `clippy --all-targets`, `doc --no-deps` and `test` clean.