### PR TITLE
refactor(overlay): move the WAD tail rebase onto ltk_wad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "ltk_wad"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a72c0141752c9d89946f0be4f5495d7aedea0f14c4bc52fbe87ced26e8c7a26d"
+checksum = "35e3afdb79e9329f7ff8bee7afb507359abcea9a60686ca24fe77206495943be"
 dependencies = [
  "byteorder",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ members = [
 camino = "1.1"
 indexmap = { version = "2", features = ["serde"] }
 ltk_hash = "0.4"
-ltk_wad = "0.5.3"
+ltk_wad = "0.5.4"
 sysinfo = "0.32"

--- a/crates/ltk_overlay/src/builder/incremental.rs
+++ b/crates/ltk_overlay/src/builder/incremental.rs
@@ -14,9 +14,11 @@
 use crate::builder::{OverlayBuilder, OverrideMeta};
 use crate::error::{Error, Result};
 use crate::state::{OverlayState, WadLayoutRecord};
-use crate::wad_builder::{PreparedOverride, SourceWadIdentity, WadTailLayout, merged_entry_count};
+use crate::wad_builder::{OverrideEncoding as _, SourceWadIdentity};
 use camino::{Utf8Path, Utf8PathBuf};
-use ltk_wad::{Wad, WadChunk, WadChunks, WadHash};
+use ltk_wad::{
+    EncodedChunk, Wad, WadChunk, WadChunks, WadHash, WadRebaseError, WadRebasePlan, WadTailLayout,
+};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::BufReader;
@@ -30,9 +32,14 @@ use std::io::BufReader;
 enum RebuildReason {
     /// A file or record the plan depends on could not be read, mounted, or used.
     Unusable(Error),
-    /// The recorded layout is unusable: its own numbers do not hang together,
-    /// or a chunk it places falls outside what the format can address.
-    IncoherentLayout(crate::wad_builder::WadTailError),
+    /// The rebase refused the recorded layout, or gave out reading it.
+    ///
+    /// Usually what the name says: the layout's own numbers do not hang
+    /// together, or a chunk it places falls outside what the format can
+    /// address. [`WadRebaseError`] also carries I/O, though, so a target that
+    /// gave out underneath the planner arrives here too. All of them mean the
+    /// same thing to the caller, which is to rebuild this WAD in full.
+    IncoherentLayout(WadRebaseError),
     /// The game WAD is no longer the one this overlay was built from.
     GameWadChanged {
         found: SourceWadIdentity,
@@ -58,8 +65,8 @@ impl From<Error> for RebuildReason {
     }
 }
 
-impl From<crate::wad_builder::WadTailError> for RebuildReason {
-    fn from(error: crate::wad_builder::WadTailError) -> Self {
+impl From<WadRebaseError> for RebuildReason {
+    fn from(error: WadRebaseError) -> Self {
         Self::IncoherentLayout(error)
     }
 }
@@ -145,7 +152,7 @@ pub(crate) struct TailRewrite {
     /// Overrides whose compressed bytes were lifted out of the old tail because
     /// their content is unchanged. The rest of [`tail_hashes`](Self::tail_hashes)
     /// is resolved and compressed by the normal pass-2 path.
-    pub(crate) reused: HashMap<WadHash, PreparedOverride>,
+    pub(crate) reused: HashMap<WadHash, EncodedChunk>,
 }
 
 impl OverlayBuilder {
@@ -261,7 +268,8 @@ impl OverlayBuilder {
 
         // The new override set must fit the TOC the file already reserved.
         let base_entries = base_entries(&record.layout, source.chunks())?;
-        let entry_count = merged_entry_count(&base_entries, new_overrides.iter().copied());
+        let entry_count =
+            WadRebasePlan::merged_entry_count(&base_entries, new_overrides.iter().copied());
         if !record.layout.admits_entry_count(entry_count) {
             return Err(RebuildReason::CapacityMismatch {
                 needed: entry_count,
@@ -360,7 +368,7 @@ fn reuse_unchanged_overrides<S: std::io::Read + std::io::Seek>(
     record: &WadLayoutRecord,
     tail_hashes: &[WadHash],
     all_meta: &HashMap<WadHash, OverrideMeta>,
-) -> std::result::Result<HashMap<WadHash, PreparedOverride>, RebuildReason> {
+) -> std::result::Result<HashMap<WadHash, EncodedChunk>, RebuildReason> {
     let mut reused = HashMap::new();
     for &path_hash in tail_hashes {
         let Some(meta) = all_meta.get(&path_hash) else {
@@ -377,10 +385,7 @@ fn reuse_unchanged_overrides<S: std::io::Read + std::io::Seek>(
         }
 
         let compressed = overlay.load_chunk_raw(&chunk)?;
-        reused.insert(
-            path_hash,
-            PreparedOverride::from_wad_bytes(&chunk, compressed)?,
-        );
+        reused.insert(path_hash, EncodedChunk::from_wad_bytes(&chunk, compressed)?);
     }
 
     Ok(reused)
@@ -420,7 +425,7 @@ mod tests {
             );
 
             let override_hashes: HashSet<WadHash> = [hash(SKIN)].into_iter().collect();
-            let prepared = PreparedOverride::compress(hash(SKIN), b"a modded skin")
+            let prepared = EncodedChunk::compress(hash(SKIN), b"a modded skin")
                 .expect("the override compresses");
             let stats = build_patched_wad(
                 &source_path,

--- a/crates/ltk_overlay/src/builder/incremental.rs
+++ b/crates/ltk_overlay/src/builder/incremental.rs
@@ -30,8 +30,9 @@ use std::io::BufReader;
 enum RebuildReason {
     /// A file or record the plan depends on could not be read, mounted, or used.
     Unusable(Error),
-    /// The recorded layout's own numbers do not hang together.
-    IncoherentLayout(Error),
+    /// The recorded layout is unusable: its own numbers do not hang together,
+    /// or a chunk it places falls outside what the format can address.
+    IncoherentLayout(crate::wad_builder::WadTailError),
     /// The game WAD is no longer the one this overlay was built from.
     GameWadChanged {
         found: SourceWadIdentity,
@@ -54,6 +55,12 @@ enum RebuildReason {
 impl From<Error> for RebuildReason {
     fn from(error: Error) -> Self {
         Self::Unusable(error)
+    }
+}
+
+impl From<crate::wad_builder::WadTailError> for RebuildReason {
+    fn from(error: crate::wad_builder::WadTailError) -> Self {
+        Self::IncoherentLayout(error)
     }
 }
 

--- a/crates/ltk_overlay/src/builder/mod.rs
+++ b/crates/ltk_overlay/src/builder/mod.rs
@@ -28,7 +28,7 @@
 //!    for the overrides a tail rewrite cannot lift out of the file it is about
 //!    to rewrite. Compress each distinct content once, then write every WAD in
 //!    parallel via [`build_patched_wad`](crate::wad_builder::build_patched_wad)
-//!    or [`rewrite_wad_tail`](crate::wad_builder::rewrite_wad_tail).
+//!    or a [`WadTailPlan`](crate::wad_builder::WadTailPlan).
 //! 7. Persist the new [`OverlayState`]: per-WAD fingerprints, the layout record
 //!    of every WAD now on disk, and no dirty flags.
 

--- a/crates/ltk_overlay/src/builder/mod.rs
+++ b/crates/ltk_overlay/src/builder/mod.rs
@@ -28,7 +28,7 @@
 //!    for the overrides a tail rewrite cannot lift out of the file it is about
 //!    to rewrite. Compress each distinct content once, then write every WAD in
 //!    parallel via [`build_patched_wad`](crate::wad_builder::build_patched_wad)
-//!    or a [`WadTailPlan`](crate::wad_builder::WadTailPlan).
+//!    or a [`WadRebasePlan`](ltk_wad::WadRebasePlan).
 //! 7. Persist the new [`OverlayState`]: per-WAD fingerprints, the layout record
 //!    of every WAD now on disk, and no dirty flags.
 

--- a/crates/ltk_overlay/src/builder/resolve.rs
+++ b/crates/ltk_overlay/src/builder/resolve.rs
@@ -14,9 +14,9 @@ use crate::game_index::GameIndex;
 use crate::state::OverlayState;
 use crate::strings::{self, StringPatchPlan};
 use crate::utils::{ContentHash, compute_wad_fingerprint_from_meta};
-use crate::wad_builder::{PatchedWadStats, PreparedOverride, WadTailPlan, build_patched_wad};
+use crate::wad_builder::{OverrideEncoding as _, PatchedWadStats, build_patched_wad};
 use camino::{Utf8Path, Utf8PathBuf};
-use ltk_wad::WadHash;
+use ltk_wad::{EncodedChunk, WadHash, WadRebasePlan};
 use rayon::prelude::*;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::OpenOptions;
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Uncompressed override bytes as read in pass 2, before the
-/// [`OverrideCompressor`] turns them into the compressed [`PreparedOverride`]s
+/// [`OverrideCompressor`] turns them into the encoded [`EncodedChunk`]s
 /// the writer consumes.
 pub(crate) type ResolvedChunk = SharedBytes;
 
@@ -72,15 +72,14 @@ impl<'a> ChunkSources<'a> {
 fn distribute_prepared_to_wads(
     wads_to_build: &[Utf8PathBuf],
     wad_hash_sets: &BTreeMap<Utf8PathBuf, HashSet<WadHash>>,
-    prepared: &HashMap<WadHash, PreparedOverride>,
-) -> BTreeMap<Utf8PathBuf, HashMap<WadHash, PreparedOverride>> {
-    let mut wad_overrides: BTreeMap<Utf8PathBuf, HashMap<WadHash, PreparedOverride>> =
-        BTreeMap::new();
+    prepared: &HashMap<WadHash, EncodedChunk>,
+) -> BTreeMap<Utf8PathBuf, HashMap<WadHash, EncodedChunk>> {
+    let mut wad_overrides: BTreeMap<Utf8PathBuf, HashMap<WadHash, EncodedChunk>> = BTreeMap::new();
     for wad_path in wads_to_build {
         let Some(hashes) = wad_hash_sets.get(wad_path) else {
             continue;
         };
-        let mut per_wad: HashMap<WadHash, PreparedOverride> = HashMap::with_capacity(hashes.len());
+        let mut per_wad: HashMap<WadHash, EncodedChunk> = HashMap::with_capacity(hashes.len());
         for &hash in hashes {
             if let Some(chunk) = prepared.get(&hash) {
                 per_wad.insert(hash, chunk.clone());
@@ -105,7 +104,7 @@ const BATCH_BUDGET_BYTES: usize = 256 * 1024 * 1024;
 /// supplies them only when asked to, so a content appearing under many path
 /// hashes - a chunk routed to several WADs, or two overrides carrying
 /// identical bytes - is read and compressed a single time and then shares one
-/// [`PreparedOverride`]. That structural sharing is what keeps every copy of a
+/// [`EncodedChunk`]. That structural sharing is what keeps every copy of a
 /// cross-WAD chunk on the same compressed checksum, which the game validates
 /// (see the [`wad_builder`] module docs).
 ///
@@ -121,10 +120,10 @@ const BATCH_BUDGET_BYTES: usize = 256 * 1024 * 1024;
 /// [`wad_builder`]: crate::wad_builder
 struct OverrideCompressor<'a> {
     all_meta: &'a HashMap<WadHash, OverrideMeta>,
-    reused: HashMap<WadHash, PreparedOverride>,
+    reused: HashMap<WadHash, EncodedChunk>,
     /// Compressed overrides so far, keyed by *content* hash: that is what makes
     /// one buffer serve every chunk carrying identical bytes.
-    memo: HashMap<ContentHash, PreparedOverride>,
+    memo: HashMap<ContentHash, EncodedChunk>,
     /// Every path hash `needs` or `supply` saw, mapped to its content identity,
     /// so `finish` can spread the memo back over path hashes.
     content_of: HashMap<WadHash, ContentHash>,
@@ -142,7 +141,7 @@ struct OverrideCompressor<'a> {
 impl<'a> OverrideCompressor<'a> {
     fn new(
         all_meta: &'a HashMap<WadHash, OverrideMeta>,
-        reused: HashMap<WadHash, PreparedOverride>,
+        reused: HashMap<WadHash, EncodedChunk>,
         budget: usize,
     ) -> Self {
         let content_hash_of = |path_hash: WadHash| {
@@ -227,7 +226,7 @@ impl<'a> OverrideCompressor<'a> {
     /// still gets the one buffer, which is all the game's shared-chunk rule
     /// asks for; a later build settling on the other encoding only matters to a
     /// WAD being rewritten, and those seed the memo from the tail they keep.
-    fn supply_prepared(&mut self, path_hash: WadHash, prepared: PreparedOverride) {
+    fn supply_prepared(&mut self, path_hash: WadHash, prepared: EncodedChunk) {
         let content_hash = self.record(path_hash);
         self.memo.insert(content_hash, prepared);
         self.passed_through += 1;
@@ -246,7 +245,7 @@ impl<'a> OverrideCompressor<'a> {
             batch
                 .into_par_iter()
                 .map(|(content_hash, path_hash, bytes)| {
-                    PreparedOverride::compress(path_hash, &bytes)
+                    EncodedChunk::compress(path_hash, &bytes)
                         .map(|prepared| (content_hash, prepared))
                 })
                 .collect::<Result<Vec<_>>>()?,
@@ -264,7 +263,7 @@ impl<'a> OverrideCompressor<'a> {
     /// # Errors
     ///
     /// Fails when the final batch fails to compress.
-    fn finish(mut self) -> Result<HashMap<WadHash, PreparedOverride>> {
+    fn finish(mut self) -> Result<HashMap<WadHash, EncodedChunk>> {
         self.flush()?;
 
         tracing::info!(
@@ -432,8 +431,8 @@ impl OverlayBuilder {
         wad_hash_sets: &BTreeMap<Utf8PathBuf, HashSet<WadHash>>,
         all_meta: &HashMap<WadHash, OverrideMeta>,
         string_plans: &HashMap<WadHash, StringPatchPlan>,
-        reused: HashMap<WadHash, PreparedOverride>,
-    ) -> Result<BTreeMap<Utf8PathBuf, HashMap<WadHash, PreparedOverride>>> {
+        reused: HashMap<WadHash, EncodedChunk>,
+    ) -> Result<BTreeMap<Utf8PathBuf, HashMap<WadHash, EncodedChunk>>> {
         // Every unique path hash needed across the WADs being rebuilt, minus
         // the ones a tail rewrite supplies out of the file it is rewriting.
         let needed_hashes: HashSet<WadHash> = wads_to_build
@@ -583,7 +582,7 @@ impl OverlayBuilder {
     pub(crate) fn patch_wads_parallel(
         &self,
         wads_to_build: Vec<Utf8PathBuf>,
-        mut wad_overrides: BTreeMap<Utf8PathBuf, HashMap<WadHash, PreparedOverride>>,
+        mut wad_overrides: BTreeMap<Utf8PathBuf, HashMap<WadHash, EncodedChunk>>,
         mut rewrites: BTreeMap<Utf8PathBuf, TailRewrite>,
     ) -> Result<Vec<PatchedWad>> {
         let total_wads = wads_to_build.len() as u32;
@@ -680,7 +679,7 @@ impl OverlayBuilder {
         &self,
         dst_wad_path: &Utf8Path,
         rewrite: TailRewrite,
-        overrides: &HashMap<WadHash, PreparedOverride>,
+        overrides: &HashMap<WadHash, EncodedChunk>,
     ) -> Result<WrittenWad> {
         let start = std::time::Instant::now();
         let TailRewrite {
@@ -694,7 +693,7 @@ impl OverlayBuilder {
         // failed to apply, say - is dropped rather than fatal, and its chunk
         // falls back to the entry the source region holds. That is what the
         // full-rebuild path does with it too.
-        let tail: Vec<(WadHash, PreparedOverride)> = tail_hashes
+        let tail: Vec<(WadHash, EncodedChunk)> = tail_hashes
             .into_iter()
             .filter_map(|hash| overrides.get(&hash).cloned().map(|over| (hash, over)))
             .collect();
@@ -708,7 +707,7 @@ impl OverlayBuilder {
         // The planner proved this source identity before choosing the in-place
         // path; the rewrite itself never opens the game WAD.
         let base_entry_count = base_entries.len();
-        let plan = WadTailPlan::new(&record.layout, base_entries, &tail)?;
+        let plan = WadRebasePlan::tail(&record.layout, base_entries, &tail)?;
 
         // Every check that can be made without the file has now been made, so
         // the file can be committed to. Truncating is what makes room for a
@@ -755,7 +754,7 @@ impl OverlayBuilder {
         &self,
         relative_path: &Utf8Path,
         dst_wad_path: &Utf8Path,
-        mut overrides: HashMap<WadHash, PreparedOverride>,
+        mut overrides: HashMap<WadHash, EncodedChunk>,
     ) -> Result<WrittenWad> {
         let src_wad_path = self.game_dir.join(relative_path);
         let override_hashes: HashSet<WadHash> = overrides.keys().copied().collect();
@@ -805,13 +804,13 @@ fn try_pass_through(
     wad_name: &str,
     rel_path: &Utf8Path,
     mismatches: &mut Vec<ChecksumMismatch>,
-) -> Result<Option<PreparedOverride>> {
+) -> Result<Option<EncodedChunk>> {
     let Some(chunk) = provider.read_wad_override_compressed(layer, wad_name, rel_path)? else {
         return Ok(None);
     };
 
     let claimed = chunk.claimed_checksum;
-    let Some(prepared) = PreparedOverride::pass_through(path_hash, chunk)? else {
+    let Some(prepared) = EncodedChunk::pass_through(path_hash, chunk)? else {
         return Ok(None);
     };
 
@@ -842,9 +841,9 @@ fn try_pass_through(
 ///
 /// Its bytes are then freed as soon as the last WAD holding them has written it.
 fn take_override(
-    overrides: &mut HashMap<WadHash, PreparedOverride>,
+    overrides: &mut HashMap<WadHash, EncodedChunk>,
     path_hash: WadHash,
-) -> Result<PreparedOverride> {
+) -> Result<EncodedChunk> {
     overrides.remove(&path_hash).ok_or_else(missing_override)
 }
 
@@ -859,7 +858,7 @@ fn missing_override() -> Error {
 /// One WAD's share of a parallel patch pass.
 struct WadWork {
     relative_path: Utf8PathBuf,
-    overrides: HashMap<WadHash, PreparedOverride>,
+    overrides: HashMap<WadHash, EncodedChunk>,
     /// `Some` when this WAD passed the [tail-rewrite](super::incremental)
     /// preconditions, in which case its file is kept and only its tail rewritten.
     rewrite: Option<TailRewrite>,

--- a/crates/ltk_overlay/src/builder/resolve.rs
+++ b/crates/ltk_overlay/src/builder/resolve.rs
@@ -14,11 +14,12 @@ use crate::game_index::GameIndex;
 use crate::state::OverlayState;
 use crate::strings::{self, StringPatchPlan};
 use crate::utils::{ContentHash, compute_wad_fingerprint_from_meta};
-use crate::wad_builder::{PatchedWadStats, PreparedOverride, build_patched_wad, rewrite_wad_tail};
+use crate::wad_builder::{PatchedWadStats, PreparedOverride, WadTailPlan, build_patched_wad};
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_wad::WadHash;
 use rayon::prelude::*;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs::OpenOptions;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -681,36 +682,71 @@ impl OverlayBuilder {
         rewrite: TailRewrite,
         overrides: &HashMap<WadHash, PreparedOverride>,
     ) -> Result<WrittenWad> {
+        let start = std::time::Instant::now();
+        let TailRewrite {
+            record,
+            base_entries,
+            tail_hashes,
+            ..
+        } = rewrite;
+
         // An override whose bytes never resolved - a stringtable patch that
         // failed to apply, say - is dropped rather than fatal, and its chunk
         // falls back to the entry the source region holds. That is what the
         // full-rebuild path does with it too.
-        let tail_hashes: Vec<WadHash> = rewrite
-            .tail_hashes
+        let tail: Vec<(WadHash, PreparedOverride)> = tail_hashes
             .into_iter()
-            .filter(|hash| overrides.contains_key(hash))
+            .filter_map(|hash| overrides.get(&hash).cloned().map(|over| (hash, over)))
             .collect();
 
         tracing::info!(
             "Rewriting WAD tail dst={} overrides={}",
             dst_wad_path,
-            tail_hashes.len()
+            tail.len()
         );
 
         // The planner proved this source identity before choosing the in-place
         // path; the rewrite itself never opens the game WAD.
-        let stats = rewrite_wad_tail(
+        let base_entry_count = base_entries.len();
+        let plan = WadTailPlan::new(&record.layout, base_entries, &tail)?;
+
+        // Every check that can be made without the file has now been made, so
+        // the file can be committed to. Truncating is what makes room for a
+        // tail shorter than the one the file holds, and there is no `.tmp` to
+        // discard if the write then fails - which is exactly what the caller's
+        // fallback rebuild is for.
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(dst_wad_path.as_std_path())
+            .map_err(|source| Error::write(dst_wad_path, source))?;
+        file.set_len(record.layout.tail_offset)
+            .map_err(|source| Error::write(dst_wad_path, source))?;
+
+        let mut file = file;
+        let report = plan.write(&mut file, 0)?;
+
+        let elapsed_ms = start.elapsed().as_millis();
+        tracing::info!(
+            "Rewrote WAD tail dst={} chunks={} overrides={} tail_bytes={} elapsed_ms={}",
             dst_wad_path,
-            &rewrite.record.layout,
-            rewrite.record.source,
-            rewrite.base_entries,
-            &tail_hashes,
-            |hash| overrides.get(&hash).cloned().ok_or_else(missing_override),
-        )?;
+            report.entry_count,
+            tail.len(),
+            report.tail_len,
+            elapsed_ms
+        );
 
         Ok(WrittenWad {
-            stats,
-            written_overrides: tail_hashes,
+            stats: PatchedWadStats {
+                chunks_written: report.entry_count,
+                overrides_applied: tail.len(),
+                new_entries_added: report.entry_count.saturating_sub(base_entry_count),
+                chunks_transient: report.entry_count - tail.len(),
+                elapsed_ms,
+                layout: record.layout,
+                source: record.source,
+            },
+            written_overrides: tail.into_iter().map(|(hash, _)| hash).collect(),
         })
     }
 

--- a/crates/ltk_overlay/src/builder/resolve/tests.rs
+++ b/crates/ltk_overlay/src/builder/resolve/tests.rs
@@ -157,7 +157,7 @@ fn a_passed_through_chunk_is_never_compressed_or_read_again() {
     assert!(preparer.needs(WadHash(0xAAAA)));
     preparer.supply_prepared(
         WadHash(0xAAAA),
-        PreparedOverride::pass_through(
+        EncodedChunk::pass_through(
             WadHash(0xAAAA),
             CompressedChunk {
                 compressed: stored.clone(),
@@ -197,7 +197,7 @@ fn reused_content_is_never_requested() {
         (WadHash(0xBBBB), meta_with_content_hash(ContentHash(9))),
     ]);
     let reused_override =
-        PreparedOverride::compress(WadHash(0xAAAA), b"recovered from the tail").unwrap();
+        EncodedChunk::compress(WadHash(0xAAAA), b"recovered from the tail").unwrap();
     let reused = HashMap::from([(WadHash(0xAAAA), reused_override)]);
     let mut preparer = OverrideCompressor::new(&all_meta, reused, BATCH_BUDGET_BYTES);
 

--- a/crates/ltk_overlay/src/error.rs
+++ b/crates/ltk_overlay/src/error.rs
@@ -116,6 +116,10 @@ pub enum Error {
     #[error(transparent)]
     WadLimit(#[from] WadLimitError),
 
+    /// A WAD's tail could not be rewritten.
+    #[error(transparent)]
+    WadTail(#[from] crate::wad_builder::WadTailError),
+
     /// A file is not what its own metadata says it is.
     #[error(transparent)]
     Corrupt(#[from] CorruptionError),

--- a/crates/ltk_overlay/src/error.rs
+++ b/crates/ltk_overlay/src/error.rs
@@ -116,9 +116,9 @@ pub enum Error {
     #[error(transparent)]
     WadLimit(#[from] WadLimitError),
 
-    /// A WAD's tail could not be rewritten.
+    /// A WAD could not be rebased.
     #[error(transparent)]
-    WadTail(#[from] crate::wad_builder::WadTailError),
+    WadRebase(#[from] ltk_wad::WadRebaseError),
 
     /// A file is not what its own metadata says it is.
     #[error(transparent)]
@@ -261,6 +261,12 @@ pub enum WadLimitError {
 
     /// A chunk shifted into the copied region falls outside the format's `u32`
     /// offset fields.
+    ///
+    /// Nothing constructs this any more: shifting moved to
+    /// [`ltk_wad::WadTailLayout::shifted`], which reports its own
+    /// [`ltk_wad::WadRebaseError::ChunkUnaddressable`]. Left in place because
+    /// pruning the dead variants is its own decision, not one to take in passing
+    /// while moving the mechanism out.
     #[error("chunk {path_hash:016x} cannot be addressed at offset {offset}")]
     ChunkUnaddressable { path_hash: WadHash, offset: i64 },
 
@@ -268,6 +274,11 @@ pub enum WadLimitError {
     ///
     /// While `TOC_SLACK_ENTRIES` is zero this also fires when the set *shrinks*,
     /// because capacity is then exactly the entry count.
+    ///
+    /// Unconstructible for the same reason as
+    /// [`ChunkUnaddressable`](Self::ChunkUnaddressable): the capacity check runs
+    /// inside a rebase now, and reports
+    /// [`ltk_wad::WadRebaseError::TocCapacity`].
     #[error("{wad} reserved {reserved} TOC entries, not the {needed} this rebuild needs")]
     TocCapacity {
         wad: Utf8PathBuf,

--- a/crates/ltk_overlay/src/state.rs
+++ b/crates/ltk_overlay/src/state.rs
@@ -15,9 +15,9 @@
 use crate::error::{Error, Result};
 use crate::linked_bins::LinkedBinOffender;
 use crate::utils::ContentHash;
-use crate::wad_builder::{SourceWadIdentity, WadTailLayout};
+use crate::wad_builder::SourceWadIdentity;
 use camino::{Utf8Path, Utf8PathBuf};
-use ltk_wad::WadHash;
+use ltk_wad::{WadHash, WadTailLayout};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -765,6 +765,49 @@ mod tests {
             loaded.wad_layout("DATA/FINAL/Champions/Ahri.wad.client"),
             Some(&record)
         );
+    }
+
+    /// The layout's four keys are a wire format `ltk_wad` now owns.
+    ///
+    /// A rename there would not fail a build here: the record would simply stop
+    /// deserializing, `wad_layout` would answer `None`, and every WAD would
+    /// quietly fall back to a full rebuild - the exact cost this record exists
+    /// to avoid, lost silently.
+    ///
+    /// So the compatibility direction is pinned against bytes rather than
+    /// against a round trip, which would agree with itself whatever names
+    /// `ltk_wad` chose. This JSON is what league-mod wrote before the layout
+    /// moved out of `wad_builder`.
+    #[test]
+    fn a_layout_written_before_the_move_still_loads() {
+        const WRITTEN_BY_932574F: &str = r#"{
+            "source": {"len": 4096, "mtime": 1700000000000000000, "tocHash": 118230807},
+            "layout": {
+                "dataRegionOffset": 500,
+                "offsetDelta": 0,
+                "tailOffset": 4000,
+                "tocCapacity": 7
+            },
+            "overrides": {"43690": 4369}
+        }"#;
+
+        let loaded: WadLayoutRecord =
+            serde_json::from_str(WRITTEN_BY_932574F).expect("an older record still deserializes");
+        assert_eq!(loaded, layout_record(&[(WadHash(0xAAAA), 0x1111)]));
+
+        // And the writing direction, so a rename cannot land silently either.
+        let json = serde_json::to_string(&loaded).expect("a record serializes");
+        for key in [
+            "dataRegionOffset",
+            "offsetDelta",
+            "tailOffset",
+            "tocCapacity",
+        ] {
+            assert!(
+                json.contains(&format!("\"{key}\"")),
+                "the layout must still write {key}, got {json}"
+            );
+        }
     }
 
     /// Both sides of an `overrides` entry are newtypes over `u64`, and both

--- a/crates/ltk_overlay/src/wad_builder.rs
+++ b/crates/ltk_overlay/src/wad_builder.rs
@@ -63,7 +63,7 @@ use ltk_file::LeagueFileKind;
 use ltk_wad::{FileExt as _, Wad, WadChunk, WadChunkCompression, WadChunks, WadHash};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashSet};
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{BufWriter, Cursor, Seek, SeekFrom, Write};
 use std::ops::Range;
 use std::sync::Arc;
@@ -104,6 +104,79 @@ const TOC_SLACK_ENTRIES: u32 = 0;
 
 /// Highest byte offset the WAD v3.4 format's `u32` offset fields can address.
 const MAX_WAD_OFFSET: u64 = u32::MAX as u64;
+
+/// Why a WAD's tail could not be rewritten.
+///
+/// Everything the tail rewrite alone can refuse, named without reference to
+/// where the WAD lives: it is handed a seekable target and a base offset, so it
+/// has no path to put in a message. A caller that has one attaches it.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WadTailError {
+    /// The recorded layout does not place its regions past a header, a chunk
+    /// count and a TOC of the recorded capacity.
+    #[error(
+        "a layout reserving {toc_capacity} TOC entries cannot put its data region at \
+         {data_region_offset} and its tail at {tail_offset}"
+    )]
+    IncoherentLayout {
+        /// TOC entries the layout reserved.
+        toc_capacity: u32,
+        /// Where the layout puts the copied source data region.
+        data_region_offset: u64,
+        /// Where the layout puts the override tail.
+        tail_offset: u64,
+    },
+
+    /// The rewritten TOC no longer fits the capacity the file reserved.
+    #[error("the WAD reserved {reserved} TOC entries, not the {needed} this rewrite needs")]
+    TocCapacity {
+        /// Entries the rewritten TOC would hold.
+        needed: usize,
+        /// Entries the file has room for.
+        reserved: u32,
+    },
+
+    /// The tail would reach past what the format's `u32` offsets can address.
+    #[error(
+        "the override tail would reach offset {offset}, past the 4 GiB the WAD v3.4 \
+         format can address"
+    )]
+    TailTooLarge {
+        /// The offset the tail would have reached.
+        offset: u64,
+    },
+
+    /// A source chunk's shifted range falls outside the addressable file.
+    #[error("chunk {path_hash:016x} cannot be addressed at offset {offset}")]
+    ChunkUnaddressable {
+        /// The chunk that would not fit.
+        path_hash: WadHash,
+        /// Where shifting would have put it.
+        offset: i64,
+    },
+
+    /// A TOC entry could not be encoded.
+    #[error(transparent)]
+    Wad(#[from] ltk_wad::WadError),
+
+    /// The target refused a write or a seek.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+/// What a tail rewrite wrote.
+///
+/// The numbers the write itself produced, and nothing the caller already held:
+/// the layout it passed in, the source it verified and the time it chose to
+/// measure are all its own to report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WadTailReport {
+    /// Entries in the rewritten TOC.
+    pub entry_count: usize,
+    /// Bytes the override tail now occupies.
+    pub tail_len: u64,
+}
 
 /// An override chunk's compressed bytes plus the TOC fields describing them.
 ///
@@ -350,7 +423,7 @@ impl WadTailLayout {
     /// deserialized from a state file that anything could have written, and the
     /// result is a seek target in a file the game loads, so the subtraction
     /// reports rather than wraps.
-    pub fn toc_offset(&self) -> Result<u64> {
+    pub fn toc_offset(&self) -> std::result::Result<u64, WadTailError> {
         self.chunk_count_offset()
             .map(|offset| offset + size_of::<u32>() as u64)
     }
@@ -361,19 +434,16 @@ impl WadTailLayout {
     ///
     /// Fails on the same layouts as [`toc_offset`](Self::toc_offset), of which
     /// this is the lower bound.
-    pub fn chunk_count_offset(&self) -> Result<u64> {
+    pub fn chunk_count_offset(&self) -> std::result::Result<u64, WadTailError> {
         let below_region =
             u64::from(self.toc_capacity) * TOC_ENTRY_SIZE as u64 + size_of::<u32>() as u64;
         self.data_region_offset
             .checked_sub(below_region)
             .filter(|&offset| offset >= WAD_HEADER_SIZE)
-            .ok_or_else(|| {
-                CorruptionError::IncoherentLayout {
-                    toc_capacity: self.toc_capacity,
-                    data_region_offset: self.data_region_offset,
-                    tail_offset: self.tail_offset,
-                }
-                .into()
+            .ok_or(WadTailError::IncoherentLayout {
+                toc_capacity: self.toc_capacity,
+                data_region_offset: self.data_region_offset,
+                tail_offset: self.tail_offset,
             })
     }
 
@@ -387,15 +457,14 @@ impl WadTailLayout {
     ///
     /// Fails when the shifted range falls outside what the format's `u32`
     /// offset fields can address.
-    pub fn shifted(&self, orig: &WadChunk) -> Result<WadChunk> {
+    pub fn shifted(&self, orig: &WadChunk) -> std::result::Result<WadChunk, WadTailError> {
         let shifted = orig.data_offset as i64 + self.offset_delta;
         let end = shifted + orig.compressed_size as i64;
         if shifted < 0 || end > MAX_WAD_OFFSET as i64 {
-            return Err(WadLimitError::ChunkUnaddressable {
+            return Err(WadTailError::ChunkUnaddressable {
                 path_hash: orig.path_hash,
                 offset: shifted,
-            }
-            .into());
+            });
         }
 
         Ok(WadChunk {
@@ -428,15 +497,14 @@ impl WadTailLayout {
     /// Fails when the region does not start past a header, a chunk count and a
     /// TOC of the recorded capacity, or when the tail starts before the region
     /// does.
-    pub fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> std::result::Result<(), WadTailError> {
         self.chunk_count_offset()?;
         if self.tail_offset < self.data_region_offset {
-            return Err(CorruptionError::IncoherentLayout {
+            return Err(WadTailError::IncoherentLayout {
                 toc_capacity: self.toc_capacity,
                 data_region_offset: self.data_region_offset,
                 tail_offset: self.tail_offset,
-            }
-            .into());
+            });
         }
         Ok(())
     }
@@ -677,7 +745,6 @@ fn write_patched_wad(
                     *path_hash,
                     &over,
                     &mut tail_cursor,
-                    dst_wad_path,
                 )?);
             }
             PlannedEntry::Transient(orig) => final_chunks.push(layout.shifted(orig)?),
@@ -722,144 +789,159 @@ fn write_patched_wad(
     })
 }
 
-/// Rebuild a patched WAD by rewriting only its override tail and its TOC.
+/// A checked plan to rewrite a WAD's override tail and its TOC.
 ///
-/// The file keeps its header and its copied source data region - the bytes that
-/// dominate a game WAD - so the work is bounded by the override bytes, not by
-/// the WAD's size. Everything this needs to be safe has been decided by the
-/// caller: `layout` and `base_entries` describe a file whose identity and TOC
-/// it already verified against the game WAD and the recorded layout.
+/// The file keeps its header and its copied source data region - the bytes
+/// that dominate a game WAD - so the work is bounded by the override bytes,
+/// not by the WAD's size.
 ///
-/// # Arguments
+/// Building a plan performs every check that can be made without touching the
+/// WAD; [`write`](Self::write) then consumes it. That split is the whole point
+/// of the type. Rewriting in place is destructive by nature, so a caller has to
+/// commit to it before a byte is written, by truncating a file or growing an
+/// entry inside a container, and a plan is the proof that committing is safe.
+/// [`tail_len`](Self::tail_len) reports how far a container's own bytes move,
+/// which such a caller also needs before it starts.
 ///
-/// * `wad_path` - The overlay WAD to rewrite in place.
-/// * `layout` - The layout recorded when this file was built.
-/// * `source` - The game WAD this file was built from, which the caller has
-///   already verified is unchanged. Reported back in the stats: a rewrite never
-///   opens the source itself, so it cannot re-derive this.
-/// * `base_entries` - The TOC entry each chunk already in the copied region
-///   would have with no override applied, keyed by path hash. A tail hash
-///   overwrites its entry here, so a chunk whose override is gone reverts to the
-///   bytes the region still holds. Consumed and written back out as the new TOC,
-///   which for a map WAD is tens of thousands of entries not worth copying.
-/// * `tail_hashes` - Path hashes whose data goes into the new tail, ascending.
-///   An ordered slice rather than the set [`build_patched_wad`] takes: that one
-///   only asks each source chunk whether it is overridden, while this writes the
-///   tail in the given order and needs it to match the TOC it produces.
-/// * `resolve_override` - Supplies each tail hash's compressed bytes, in the
-///   order they are written.
-///
-/// # Errors
-///
-/// Fails when the recorded layout is incoherent, when the resulting entry count
-/// no longer fits the reserved TOC capacity, when the tail would push the file
-/// past the format's 4 GiB limit, or when the disk refuses a write. The caller's
-/// fallback for all of these is a full rebuild.
-///
-/// Rewriting in place is destructive by nature: the file is truncated at the
-/// tail before anything is written, and there is no `.tmp` to discard. Every
-/// check that can be made without touching the file is therefore made first,
-/// and the tail's bytes are gathered before the truncation, so the only failures
-/// that can leave a torn file are I/O ones. That is what the caller's dirty
-/// marker exists to cover.
-pub fn rewrite_wad_tail(
-    wad_path: &Utf8Path,
-    layout: &WadTailLayout,
-    source: SourceWadIdentity,
-    base_entries: BTreeMap<WadHash, WadChunk>,
-    tail_hashes: &[WadHash],
-    mut resolve_override: impl FnMut(WadHash) -> Result<PreparedOverride>,
-) -> Result<PatchedWadStats> {
-    let start = std::time::Instant::now();
+/// Everything a plan needs to be *correct* has been decided by the caller:
+/// `layout` and `base_entries` describe a WAD whose identity and TOC it has
+/// already verified.
+#[derive(Debug)]
+pub struct WadTailPlan<'a> {
+    layout: WadTailLayout,
+    /// The TOC the write emits. A tail hash overwrites its entry here, so a
+    /// chunk whose override is gone reverts to the bytes the region still
+    /// holds. Consumed and written back out, which for a map WAD is tens of
+    /// thousands of entries not worth copying.
+    entries: BTreeMap<WadHash, WadChunk>,
+    tail: &'a [(WadHash, PreparedOverride)],
+    entry_count: usize,
+    tail_end: u64,
+}
 
-    layout.validate()?;
+impl<'a> WadTailPlan<'a> {
+    /// Check that `tail` can be written into the WAD `layout` describes.
+    ///
+    /// # Arguments
+    ///
+    /// * `layout` - The layout recorded when the WAD was built.
+    /// * `base_entries` - The TOC entry each chunk already in the copied region
+    ///   would have with no override applied, keyed by path hash.
+    /// * `tail` - The overrides whose bytes go into the new tail, in the order
+    ///   they are written. Their order decides where the bytes land and nothing
+    ///   else: each TOC entry carries its own offset, and the TOC itself comes
+    ///   out in hash order whatever order the tail was given in. A hash may
+    ///   appear once.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the recorded layout is incoherent, when the resulting entry
+    /// count no longer fits the reserved TOC capacity, or when the tail would
+    /// push the WAD past the format's 4 GiB limit. The caller's fallback for
+    /// all of these is a full rebuild - and because nothing has been written,
+    /// it inherits an untouched WAD.
+    pub fn new(
+        layout: &WadTailLayout,
+        base_entries: BTreeMap<WadHash, WadChunk>,
+        tail: &'a [(WadHash, PreparedOverride)],
+    ) -> std::result::Result<Self, WadTailError> {
+        layout.validate()?;
 
-    let base_entry_count = base_entries.len();
-    let entry_count = merged_entry_count(&base_entries, tail_hashes.iter().copied());
-    if !layout.admits_entry_count(entry_count) {
-        return Err(WadLimitError::TocCapacity {
-            wad: wad_path.to_path_buf(),
-            needed: entry_count,
-            reserved: layout.toc_capacity,
+        let entry_count = merged_entry_count(&base_entries, tail.iter().map(|(hash, _)| *hash));
+        if !layout.admits_entry_count(entry_count) {
+            return Err(WadTailError::TocCapacity {
+                needed: entry_count,
+                reserved: layout.toc_capacity,
+            });
         }
-        .into());
-    }
 
-    // Everything that can fail without touching the file has now been checked,
-    // and the tail's own bytes are gathered before the truncation, so the only
-    // failures past this point are the disk itself giving out.
-    let tail: Vec<(WadHash, PreparedOverride)> = tail_hashes
-        .iter()
-        .map(|&path_hash| Ok((path_hash, resolve_override(path_hash)?)))
-        .collect::<Result<_>>()?;
-    // Saturating rather than checked: any sum large enough to wrap a u64 is far
-    // past the 4 GiB limit the next check rejects it by, so there is nothing a
-    // separate overflow error would tell the caller.
-    let tail_end = tail.iter().fold(layout.tail_offset, |end, (_, over)| {
-        end.saturating_add(over.compressed().len() as u64)
-    });
-    if tail_end > MAX_WAD_OFFSET {
-        return Err(WadLimitError::FileTooLarge {
-            wad: wad_path.to_path_buf(),
-            region: WadRegion::OverrideTail,
-            offset: tail_end,
+        // Saturating rather than checked: any sum large enough to wrap a u64 is
+        // far past the 4 GiB limit the next check rejects it by, so there is
+        // nothing a separate overflow error would tell the caller.
+        let tail_end = tail.iter().fold(layout.tail_offset, |end, (_, over)| {
+            end.saturating_add(over.compressed().len() as u64)
+        });
+        if tail_end > MAX_WAD_OFFSET {
+            return Err(WadTailError::TailTooLarge { offset: tail_end });
         }
-        .into());
+
+        Ok(Self {
+            layout: *layout,
+            entries: base_entries,
+            tail,
+            entry_count,
+            tail_end,
+        })
     }
 
-    let file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(wad_path.as_std_path())
-        .map_err(|source| Error::write(wad_path, source))?;
-    file.set_len(layout.tail_offset)
-        .map_err(|source| Error::write(wad_path, source))?;
-
-    let mut writer = BufWriter::with_capacity(WRITE_BUFFER_SIZE, file);
-    writer.seek(SeekFrom::Start(layout.tail_offset))?;
-
-    let mut entries = base_entries;
-    let mut tail_cursor = layout.tail_offset;
-    for (path_hash, over) in &tail {
-        let chunk = write_tail_chunk(&mut writer, *path_hash, over, &mut tail_cursor, wad_path)?;
-        entries.insert(*path_hash, chunk);
+    /// Bytes the rewritten override tail will occupy.
+    #[must_use]
+    pub fn tail_len(&self) -> u64 {
+        self.tail_end - self.layout.tail_offset
     }
 
-    // `entries` is a BTreeMap, so this walks the TOC in ascending hash order.
-    writer.seek(SeekFrom::Start(layout.chunk_count_offset()?))?;
-    writer.write_u32::<LE>(entries.len() as u32)?;
-    for chunk in entries.values() {
-        chunk.write_v3_4(&mut writer)?;
-    }
-    // Reserved slots this build did not fill are zeroed, as the full-rebuild
-    // path zeroes them: rewriting in place would otherwise leave the previous
-    // build's entries sitting past the new chunk count. Empty while
-    // `TOC_SLACK_ENTRIES` is zero, since capacity then equals the entry count.
-    for _ in entries.len()..layout.toc_capacity as usize {
-        writer.write_all(&[0u8; TOC_ENTRY_SIZE])?;
+    /// Entries the rewritten TOC will hold.
+    #[must_use]
+    pub fn entry_count(&self) -> usize {
+        self.entry_count
     }
 
-    writer.flush()?;
+    /// Write the tail and the TOC into `wad`, whose first byte is at `base`.
+    ///
+    /// `base` is where the WAD begins inside whatever holds it: `0` for a file
+    /// that is one WAD, and the entry's offset for a WAD stored inside an
+    /// archive. It shifts every seek and no recorded offset - a TOC entry
+    /// counts from the WAD's own first byte, because the game reads the WAD
+    /// without knowing what it is stored in.
+    ///
+    /// The caller owns the container, so the caller makes room: a file is
+    /// truncated to the layout's tail offset before this is called, and a WAD
+    /// inside an archive has its entry grown or shrunk by the difference
+    /// [`tail_len`](Self::tail_len) reports.
+    ///
+    /// # Errors
+    ///
+    /// Fails when the target refuses a write or a seek, or when a TOC entry
+    /// cannot be encoded. Every check that does not need the target was made
+    /// when the plan was built, so a failure here means the target itself gave
+    /// out - and, the write being in place, may leave a torn WAD. That is what
+    /// a caller's dirty marker exists to cover.
+    pub fn write<W: Write + Seek>(
+        mut self,
+        wad: &mut W,
+        base: u64,
+    ) -> std::result::Result<WadTailReport, WadTailError> {
+        let mut writer = BufWriter::with_capacity(WRITE_BUFFER_SIZE, wad);
+        writer.seek(SeekFrom::Start(base + self.layout.tail_offset))?;
 
-    let elapsed_ms = start.elapsed().as_millis();
-    tracing::info!(
-        "Rewrote WAD tail dst={} chunks={} overrides={} tail_bytes={} elapsed_ms={}",
-        wad_path,
-        entries.len(),
-        tail_hashes.len(),
-        tail_cursor - layout.tail_offset,
-        elapsed_ms
-    );
+        let mut cursor = self.layout.tail_offset;
+        for (path_hash, over) in self.tail {
+            let chunk = write_tail_chunk(&mut writer, *path_hash, over, &mut cursor)?;
+            self.entries.insert(*path_hash, chunk);
+        }
+        let tail_len = cursor - self.layout.tail_offset;
 
-    Ok(PatchedWadStats {
-        chunks_written: entries.len(),
-        overrides_applied: tail_hashes.len(),
-        new_entries_added: entries.len().saturating_sub(base_entry_count),
-        chunks_transient: entries.len() - tail_hashes.len(),
-        elapsed_ms,
-        layout: *layout,
-        source,
-    })
+        // `entries` is a BTreeMap, so this walks the TOC in ascending hash order.
+        writer.seek(SeekFrom::Start(base + self.layout.chunk_count_offset()?))?;
+        writer.write_u32::<LE>(self.entries.len() as u32)?;
+        for chunk in self.entries.values() {
+            chunk.write_v3_4(&mut writer)?;
+        }
+        // Reserved slots this build did not fill are zeroed, as the full-rebuild
+        // path zeroes them: rewriting in place would otherwise leave the previous
+        // build's entries sitting past the new chunk count. Empty while
+        // `TOC_SLACK_ENTRIES` is zero, since capacity then equals the entry count.
+        for _ in self.entries.len()..self.layout.toc_capacity as usize {
+            writer.write_all(&[0u8; TOC_ENTRY_SIZE])?;
+        }
+
+        writer.flush()?;
+
+        Ok(WadTailReport {
+            entry_count: self.entries.len(),
+            tail_len,
+        })
+    }
 }
 
 /// Place the source region and the tail behind a TOC of `toc_capacity` entries.
@@ -982,17 +1064,11 @@ fn write_tail_chunk<W: Write>(
     path_hash: WadHash,
     over: &PreparedOverride,
     cursor: &mut u64,
-    dst_wad_path: &Utf8Path,
-) -> Result<WadChunk> {
+) -> std::result::Result<WadChunk, WadTailError> {
     let compressed_size = over.compressed().len();
     let end = *cursor + compressed_size as u64;
     if end > MAX_WAD_OFFSET {
-        return Err(WadLimitError::FileTooLarge {
-            wad: dst_wad_path.to_path_buf(),
-            region: WadRegion::OverrideTail,
-            offset: end,
-        }
-        .into());
+        return Err(WadTailError::TailTooLarge { offset: end });
     }
 
     let chunk = WadChunk {

--- a/crates/ltk_overlay/src/wad_builder.rs
+++ b/crates/ltk_overlay/src/wad_builder.rs
@@ -32,6 +32,12 @@
 //! - the only bytes an incremental rebuild must rewrite are the tail and the
 //!   TOC, which is what makes rebuilding a WAD cost O(override bytes).
 //!
+//! That last one is [`ltk_wad::WadRebasePlan::tail`]'s job rather than this
+//! module's: the layout recorded here is [`WadTailLayout`], and a later build
+//! hands it back to `ltk_wad` to rewrite the file in place. What stays here is
+//! the full rebuild that lays a WAD out this way to begin with, and the codec
+//! policy deciding what an override's bytes are encoded with.
+//!
 //! # Compression Strategy
 //!
 //! **Transient chunks** - those no mod overrides, which merely transit the build -
@@ -39,20 +45,20 @@
 //! decompression or recompression occurs. This is the fast path for the vast
 //! majority of chunks.
 //!
-//! **Override chunks** arrive already compressed, as [`PreparedOverride`] values.
-//! [`PreparedOverride::compress`] auto-detects an override's file type via
+//! **Override chunks** arrive already encoded, as [`EncodedChunk`] values.
+//! [`OverrideEncoding::compress`] auto-detects an override's file type via
 //! [`LeagueFileKind::identify_from_bytes`] and applies the ideal compression:
 //!
 //! - **Audio files** (Wwise Bank / Wwise Package): stored uncompressed (`None`).
 //! - **Everything else**: compressed with Zstd at level 3.
 //!
 //! An override whose mod already holds it as a WAD chunk skips both steps:
-//! `PreparedOverride::pass_through` adopts those stored bytes verbatim, so
+//! [`OverrideEncoding::pass_through`] adopts those stored bytes verbatim, so
 //! nothing is decoded or re-encoded on the way into the overlay.
 //!
 //! League validates a chunk shared across WADs by its **compressed** checksum, so
 //! every WAD holding a given chunk must receive the same bytes. Compressing once
-//! and sharing the [`PreparedOverride`] guarantees that structurally, without
+//! and sharing the [`EncodedChunk`] guarantees that structurally, without
 //! relying on the compressor being deterministic across versions.
 
 use crate::content::CompressedChunk;
@@ -61,23 +67,21 @@ use byteorder::{LE, WriteBytesExt};
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_file::LeagueFileKind;
 use ltk_wad::{FileExt as _, Wad, WadChunk, WadChunkCompression, WadChunks, WadHash};
+
+// Both appear in this module's own public signatures - `PatchedWadStats::layout`
+// is a `WadTailLayout`, and `build_patched_wad` resolves overrides to
+// `EncodedChunk`s - so they stay nameable from here rather than making a caller
+// reach into `ltk_wad` to spell this module's types.
+pub use ltk_wad::{EncodedChunk, WadTailLayout};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufWriter, Cursor, Seek, SeekFrom, Write};
 use std::ops::Range;
-use std::sync::Arc;
 use xxhash_rust::xxh3::xxh3_64;
 
 /// Size of a single v3.4 WAD TOC entry.
 const TOC_ENTRY_SIZE: usize = 32;
-
-/// Size of the v3.4 WAD header, which every other offset in the file follows.
-///
-/// 2 bytes of `RW` magic, 2 of version, 256 of RSA signature and 8 of checksum.
-/// The `u32` chunk count sits directly on top of it and the TOC directly on top
-/// of that, so the first TOC entry of a well-formed v3.4 WAD begins at 272.
-const WAD_HEADER_SIZE: u64 = 268;
 
 /// Write buffer size for the output WAD
 const WRITE_BUFFER_SIZE: usize = 1 << 20; // 1 MiB
@@ -105,118 +109,43 @@ const TOC_SLACK_ENTRIES: u32 = 0;
 /// Highest byte offset the WAD v3.4 format's `u32` offset fields can address.
 const MAX_WAD_OFFSET: u64 = u32::MAX as u64;
 
-/// Why a WAD's tail could not be rewritten.
+/// The three ways this crate obtains an override's encoded bytes.
 ///
-/// Everything the tail rewrite alone can refuse, named without reference to
-/// where the WAD lives: it is handed a seekable target and a base offset, so it
-/// has no path to put in a message. A caller that has one attaches it.
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum WadTailError {
-    /// The recorded layout does not place its regions past a header, a chunk
-    /// count and a TOC of the recorded capacity.
-    #[error(
-        "a layout reserving {toc_capacity} TOC entries cannot put its data region at \
-         {data_region_offset} and its tail at {tail_offset}"
-    )]
-    IncoherentLayout {
-        /// TOC entries the layout reserved.
-        toc_capacity: u32,
-        /// Where the layout puts the copied source data region.
-        data_region_offset: u64,
-        /// Where the layout puts the override tail.
-        tail_offset: u64,
-    },
-
-    /// The rewritten TOC no longer fits the capacity the file reserved.
-    #[error("the WAD reserved {reserved} TOC entries, not the {needed} this rewrite needs")]
-    TocCapacity {
-        /// Entries the rewritten TOC would hold.
-        needed: usize,
-        /// Entries the file has room for.
-        reserved: u32,
-    },
-
-    /// The tail would reach past what the format's `u32` offsets can address.
-    #[error(
-        "the override tail would reach offset {offset}, past the 4 GiB the WAD v3.4 \
-         format can address"
-    )]
-    TailTooLarge {
-        /// The offset the tail would have reached.
-        offset: u64,
-    },
-
-    /// A source chunk's shifted range falls outside the addressable file.
-    #[error("chunk {path_hash:016x} cannot be addressed at offset {offset}")]
-    ChunkUnaddressable {
-        /// The chunk that would not fit.
-        path_hash: WadHash,
-        /// Where shifting would have put it.
-        offset: i64,
-    },
-
-    /// A TOC entry could not be encoded.
-    #[error(transparent)]
-    Wad(#[from] ltk_wad::WadError),
-
-    /// The target refused a write or a seek.
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-}
-
-/// What a tail rewrite wrote.
+/// Encode them fresh ([`compress`](Self::compress)), recover them from an
+/// overlay this crate wrote earlier ([`from_wad_bytes`](Self::from_wad_bytes)),
+/// or adopt them from a mod that already holds the chunk encoded
+/// ([`pass_through`](Self::pass_through)). Which codecs are acceptable in each
+/// case is the overlay's policy and not the WAD format's, so it stays here
+/// while the chunk type it produces lives in `ltk_wad` - where a rebase can
+/// take one without depending on this crate.
 ///
-/// The numbers the write itself produced, and nothing the caller already held:
-/// the layout it passed in, the source it verified and the time it chose to
-/// measure are all its own to report.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct WadTailReport {
-    /// Entries in the rewritten TOC.
-    pub entry_count: usize,
-    /// Bytes the override tail now occupies.
-    pub tail_len: u64,
-}
-
-/// An override chunk's compressed bytes plus the TOC fields describing them.
+/// An extension trait rather than a wrapper type: the four accessors a newtype
+/// would forward are already [`EncodedChunk`]'s own, so wrapping would buy a
+/// layer that every call site unwraps again before handing the chunk to a
+/// rebase. Import it for its constructors and nothing else - `use ... as _` is
+/// enough. It is sealed: [`EncodedChunk`] is the only sensible implementer, and
+/// these return this crate's [`Result`], which no foreign type could produce
+/// without manufacturing an [`Error`].
 ///
-/// Built once per distinct override content and shared by every WAD the override
-/// routes to, so all copies of a chunk carry identical bytes and therefore one
-/// compressed checksum - which is what the game validates a shared chunk by.
-///
-/// Cloning is cheap: the bytes live behind an [`Arc`].
-#[derive(Debug, Clone)]
-pub struct PreparedOverride {
-    compressed: Arc<[u8]>,
-    uncompressed_size: u32,
-    compression: WadChunkCompression,
-    /// xxh3_64 of `compressed`, the chunk's TOC checksum field.
-    checksum: u64,
-}
-
-impl PreparedOverride {
+/// Building an [`EncodedChunk`] hashes its bytes, so every one of these
+/// produces a TOC checksum that describes the bytes it points at rather than
+/// one some container claimed. That matters because League validates a chunk
+/// shared across WADs by its compressed checksum, and kills the process over a
+/// chunk whose checksum disagrees with its content.
+pub trait OverrideEncoding: sealed::Sealed + Sized {
     /// Compress `data` with the ideal codec for its detected file type.
     ///
     /// Audio is stored uncompressed, everything else Zstd level 3 (see the
-    /// [module docs](self)). `path_hash` only names the chunk in error messages.
+    /// [module docs](self)). `path_hash` only names the chunk in error
+    /// messages.
     ///
     /// # Errors
     ///
     /// Returns an error when the compressed or uncompressed size overflows the
     /// WAD v3.4 format's `u32` size fields.
-    pub fn compress(path_hash: WadHash, data: &[u8]) -> Result<Self> {
-        let codec = OverrideCodec::for_data(data);
-        let compressed = compress_with(data, codec)?;
-        ensure_chunk_fits(path_hash, compressed.len(), data.len())?;
-        Ok(Self {
-            checksum: xxh3_64(&compressed),
-            compressed: Arc::from(compressed),
-            uncompressed_size: data.len() as u32,
-            compression: codec.as_wad_compression(),
-        })
-    }
+    fn compress(path_hash: WadHash, data: &[u8]) -> Result<Self>;
 
-    /// Recover a prepared override from bytes already compressed inside a WAD.
+    /// Recover an encoded chunk from bytes already compressed inside a WAD.
     ///
     /// Lets an unchanged override be lifted straight out of an overlay's
     /// existing tail instead of being re-read from its mod and compressed
@@ -227,35 +156,16 @@ impl PreparedOverride {
     ///
     /// Fails when the bytes do not hash to `chunk.checksum`, which means the
     /// WAD they came from is not what its own TOC says it is.
-    pub(crate) fn from_wad_bytes(chunk: &WadChunk, compressed: Box<[u8]>) -> Result<Self> {
-        let checksum = xxh3_64(&compressed);
-        if checksum != chunk.checksum {
-            return Err(CorruptionError::ChunkChecksum {
-                path_hash: chunk.path_hash,
-                found: checksum,
-                expected: chunk.checksum,
-            }
-            .into());
-        }
-
-        Ok(Self {
-            compressed: Arc::from(compressed),
-            uncompressed_size: chunk.uncompressed_size as u32,
-            compression: chunk.compression_type,
-            checksum,
-        })
-    }
+    fn from_wad_bytes(chunk: &WadChunk, compressed: Box<[u8]>) -> Result<Self>;
 
     /// Adopt a chunk's stored bytes verbatim, recomputing their checksum.
     ///
-    /// The overlay TOC carries the checksum computed here and never the one the
-    /// source claimed: the game kills the process over a chunk whose checksum
-    /// disagrees with its bytes, so a container shipping wrong metadata must not
-    /// be able to put that value in a WAD it loads. Recomputing runs at about
-    /// memcpy speed, so the copy stays the cost. Callers compare
-    /// [`checksum`](Self::checksum) against
-    /// [`CompressedChunk::claimed_checksum`] to report the disagreement, which
-    /// is a warning and never a failed build (`docs/adr/0001-*`).
+    /// The overlay TOC carries the checksum [`EncodedChunk::new`] computes and
+    /// never the one the source claimed, so a container shipping wrong metadata
+    /// cannot put that value in a WAD the game loads. Callers compare
+    /// [`EncodedChunk::checksum`] against [`CompressedChunk::claimed_checksum`]
+    /// to report the disagreement, which is a warning and never a failed build
+    /// (`docs/adr/0001-*`).
     ///
     /// `None` when the chunk is stored under a codec this crate does not emit,
     /// which leaves the caller to decode and compress it as usual.
@@ -270,7 +180,47 @@ impl PreparedOverride {
     ///
     /// Returns an error when the sizes overflow the WAD v3.4 format's `u32`
     /// size fields.
-    pub(crate) fn pass_through(path_hash: WadHash, chunk: CompressedChunk) -> Result<Option<Self>> {
+    fn pass_through(path_hash: WadHash, chunk: CompressedChunk) -> Result<Option<Self>>;
+}
+
+mod sealed {
+    /// Keeps [`OverrideEncoding`](super::OverrideEncoding) unimplementable
+    /// outside this crate, so its methods stay free to change.
+    pub trait Sealed {}
+    impl Sealed for ltk_wad::EncodedChunk {}
+}
+
+impl OverrideEncoding for EncodedChunk {
+    fn compress(path_hash: WadHash, data: &[u8]) -> Result<Self> {
+        let codec = OverrideCodec::for_data(data);
+        let compressed = compress_with(data, codec)?;
+        ensure_chunk_fits(path_hash, compressed.len(), data.len())?;
+        Ok(Self::new(
+            compressed,
+            data.len() as u32,
+            codec.as_wad_compression(),
+        ))
+    }
+
+    fn from_wad_bytes(chunk: &WadChunk, compressed: Box<[u8]>) -> Result<Self> {
+        let encoded = Self::new(
+            compressed,
+            chunk.uncompressed_size as u32,
+            chunk.compression_type,
+        );
+        if encoded.checksum() != chunk.checksum {
+            return Err(CorruptionError::ChunkChecksum {
+                path_hash: chunk.path_hash,
+                found: encoded.checksum(),
+                expected: chunk.checksum,
+            }
+            .into());
+        }
+
+        Ok(encoded)
+    }
+
+    fn pass_through(path_hash: WadHash, chunk: CompressedChunk) -> Result<Option<Self>> {
         let Some(codec) = OverrideCodec::for_stored(chunk.compression) else {
             return Ok(None);
         };
@@ -282,32 +232,11 @@ impl PreparedOverride {
         };
         ensure_chunk_fits(path_hash, compressed.len(), uncompressed_size)?;
 
-        Ok(Some(Self {
-            checksum: xxh3_64(&compressed),
-            compressed: Arc::from(compressed),
-            uncompressed_size: uncompressed_size as u32,
-            compression: codec.as_wad_compression(),
-        }))
-    }
-
-    /// The compressed bytes, written into the WAD verbatim.
-    pub fn compressed(&self) -> &[u8] {
-        &self.compressed
-    }
-
-    /// Size of the chunk before compression.
-    pub fn uncompressed_size(&self) -> u32 {
-        self.uncompressed_size
-    }
-
-    /// Codec [`compressed`](Self::compressed) is encoded with.
-    pub fn compression(&self) -> WadChunkCompression {
-        self.compression
-    }
-
-    /// xxh3_64 of the compressed bytes - the chunk's TOC checksum.
-    pub fn checksum(&self) -> u64 {
-        self.checksum
+        Ok(Some(Self::new(
+            compressed,
+            uncompressed_size as u32,
+            codec.as_wad_compression(),
+        )))
     }
 }
 
@@ -383,130 +312,6 @@ impl PlannedEntry {
             Self::Transient(chunk) => chunk.path_hash,
             Self::Override(path_hash) => *path_hash,
         }
-    }
-}
-
-/// Where a patched WAD's regions sit, and how source offsets map into it.
-///
-/// Recorded after a build so a later rebuild of the same source WAD can verify
-/// the file it finds on disk and rewrite only its tail. See the
-/// [module docs](self) on the file layout.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WadTailLayout {
-    /// Absolute offset where the copied source data region starts.
-    pub data_region_offset: u64,
-    /// Added to a source chunk's `data_offset` to get its offset in this file.
-    ///
-    /// Signed: the patched TOC can be shorter than the source's own when the
-    /// source WAD pads between its TOC and its first chunk.
-    pub offset_delta: i64,
-    /// Absolute offset where the override tail starts (the region's end).
-    pub tail_offset: u64,
-    /// TOC entries the file has room for without moving any data.
-    ///
-    /// Equal to the entry count while `TOC_SLACK_ENTRIES` is zero.
-    pub toc_capacity: u32,
-}
-
-impl WadTailLayout {
-    /// Absolute offset of the first TOC entry.
-    ///
-    /// Derived by subtracting the TOC from the region offset rather than from
-    /// the header size, so where the region sits stays the single fact the rest
-    /// of the layout is read off.
-    ///
-    /// # Errors
-    ///
-    /// Fails when the layout does not place its region past a header, a chunk
-    /// count and a TOC of the recorded capacity. Every field here is
-    /// deserialized from a state file that anything could have written, and the
-    /// result is a seek target in a file the game loads, so the subtraction
-    /// reports rather than wraps.
-    pub fn toc_offset(&self) -> std::result::Result<u64, WadTailError> {
-        self.chunk_count_offset()
-            .map(|offset| offset + size_of::<u32>() as u64)
-    }
-
-    /// Absolute offset of the `u32` chunk count, which precedes the TOC.
-    ///
-    /// # Errors
-    ///
-    /// Fails on the same layouts as [`toc_offset`](Self::toc_offset), of which
-    /// this is the lower bound.
-    pub fn chunk_count_offset(&self) -> std::result::Result<u64, WadTailError> {
-        let below_region =
-            u64::from(self.toc_capacity) * TOC_ENTRY_SIZE as u64 + size_of::<u32>() as u64;
-        self.data_region_offset
-            .checked_sub(below_region)
-            .filter(|&offset| offset >= WAD_HEADER_SIZE)
-            .ok_or(WadTailError::IncoherentLayout {
-                toc_capacity: self.toc_capacity,
-                data_region_offset: self.data_region_offset,
-                tail_offset: self.tail_offset,
-            })
-    }
-
-    /// A source chunk's TOC entry with its offset moved into the copied region.
-    ///
-    /// Every other field carries over untouched: the bytes came out of a valid
-    /// v3.4 WAD and were copied verbatim, so their sizes, compression, frame
-    /// fields and checksum still describe them exactly.
-    ///
-    /// # Errors
-    ///
-    /// Fails when the shifted range falls outside what the format's `u32`
-    /// offset fields can address.
-    pub fn shifted(&self, orig: &WadChunk) -> std::result::Result<WadChunk, WadTailError> {
-        let shifted = orig.data_offset as i64 + self.offset_delta;
-        let end = shifted + orig.compressed_size as i64;
-        if shifted < 0 || end > MAX_WAD_OFFSET as i64 {
-            return Err(WadTailError::ChunkUnaddressable {
-                path_hash: orig.path_hash,
-                offset: shifted,
-            });
-        }
-
-        Ok(WadChunk {
-            data_offset: shifted as usize,
-            ..*orig
-        })
-    }
-
-    /// Whether `entry_count` entries fit this TOC without an unreserved gap.
-    ///
-    /// The count may not exceed the capacity, nor fall short of it by more than
-    /// the reserved slack. A gap between the last TOC entry and the first data
-    /// byte is exactly what `TOC_SLACK_ENTRIES` is gated on, so at slack zero
-    /// this is equality.
-    pub fn admits_entry_count(&self, entry_count: usize) -> bool {
-        let fewest = self.toc_capacity.saturating_sub(TOC_SLACK_ENTRIES);
-        u32::try_from(entry_count).is_ok_and(|count| (fewest..=self.toc_capacity).contains(&count))
-    }
-
-    /// Check the layout's own numbers hang together before its offsets are used.
-    ///
-    /// A layout comes back from a state file that anything could have written,
-    /// and [`toc_offset`](Self::toc_offset) subtracts the TOC's size from the
-    /// region offset to produce a seek target inside a file the game will load.
-    /// Callers that got a layout from anywhere but a fresh build must run this
-    /// first.
-    ///
-    /// # Errors
-    ///
-    /// Fails when the region does not start past a header, a chunk count and a
-    /// TOC of the recorded capacity, or when the tail starts before the region
-    /// does.
-    pub fn validate(&self) -> std::result::Result<(), WadTailError> {
-        self.chunk_count_offset()?;
-        if self.tail_offset < self.data_region_offset {
-            return Err(WadTailError::IncoherentLayout {
-                toc_capacity: self.toc_capacity,
-                data_region_offset: self.data_region_offset,
-                tail_offset: self.tail_offset,
-            });
-        }
-        Ok(())
     }
 }
 
@@ -590,7 +395,7 @@ pub struct PatchedWadStats {
 ///   the actual data upfront.
 /// * `resolve_override` - Callback invoked once per override hash during the
 ///   write pass. Returns the override's already-compressed
-///   [`PreparedOverride`]. This allows the caller to lazily hand over override
+///   [`EncodedChunk`]. This allows the caller to lazily hand over override
 ///   data on demand instead of holding everything in memory, and to compress
 ///   each distinct content once across all the WADs that hold it.
 ///
@@ -611,7 +416,7 @@ pub fn build_patched_wad(
     src_wad_path: &Utf8Path,
     dst_wad_path: &Utf8Path,
     override_hashes: &HashSet<WadHash>,
-    resolve_override: impl FnMut(WadHash) -> Result<PreparedOverride>,
+    resolve_override: impl FnMut(WadHash) -> Result<EncodedChunk>,
 ) -> Result<PatchedWadStats> {
     if let Some(parent) = dst_wad_path.parent() {
         std::fs::create_dir_all(parent.as_std_path())
@@ -645,7 +450,7 @@ fn write_patched_wad(
     out_path: &Utf8Path,
     dst_wad_path: &Utf8Path,
     override_hashes: &HashSet<WadHash>,
-    mut resolve_override: impl FnMut(WadHash) -> Result<PreparedOverride>,
+    mut resolve_override: impl FnMut(WadHash) -> Result<EncodedChunk>,
 ) -> Result<PatchedWadStats> {
     let start = std::time::Instant::now();
 
@@ -745,6 +550,7 @@ fn write_patched_wad(
                     *path_hash,
                     &over,
                     &mut tail_cursor,
+                    dst_wad_path,
                 )?);
             }
             PlannedEntry::Transient(orig) => final_chunks.push(layout.shifted(orig)?),
@@ -787,161 +593,6 @@ fn write_patched_wad(
             chunks,
         )?,
     })
-}
-
-/// A checked plan to rewrite a WAD's override tail and its TOC.
-///
-/// The file keeps its header and its copied source data region - the bytes
-/// that dominate a game WAD - so the work is bounded by the override bytes,
-/// not by the WAD's size.
-///
-/// Building a plan performs every check that can be made without touching the
-/// WAD; [`write`](Self::write) then consumes it. That split is the whole point
-/// of the type. Rewriting in place is destructive by nature, so a caller has to
-/// commit to it before a byte is written, by truncating a file or growing an
-/// entry inside a container, and a plan is the proof that committing is safe.
-/// [`tail_len`](Self::tail_len) reports how far a container's own bytes move,
-/// which such a caller also needs before it starts.
-///
-/// Everything a plan needs to be *correct* has been decided by the caller:
-/// `layout` and `base_entries` describe a WAD whose identity and TOC it has
-/// already verified.
-#[derive(Debug)]
-pub struct WadTailPlan<'a> {
-    layout: WadTailLayout,
-    /// The TOC the write emits. A tail hash overwrites its entry here, so a
-    /// chunk whose override is gone reverts to the bytes the region still
-    /// holds. Consumed and written back out, which for a map WAD is tens of
-    /// thousands of entries not worth copying.
-    entries: BTreeMap<WadHash, WadChunk>,
-    tail: &'a [(WadHash, PreparedOverride)],
-    entry_count: usize,
-    tail_end: u64,
-}
-
-impl<'a> WadTailPlan<'a> {
-    /// Check that `tail` can be written into the WAD `layout` describes.
-    ///
-    /// # Arguments
-    ///
-    /// * `layout` - The layout recorded when the WAD was built.
-    /// * `base_entries` - The TOC entry each chunk already in the copied region
-    ///   would have with no override applied, keyed by path hash.
-    /// * `tail` - The overrides whose bytes go into the new tail, in the order
-    ///   they are written. Their order decides where the bytes land and nothing
-    ///   else: each TOC entry carries its own offset, and the TOC itself comes
-    ///   out in hash order whatever order the tail was given in. A hash may
-    ///   appear once.
-    ///
-    /// # Errors
-    ///
-    /// Fails when the recorded layout is incoherent, when the resulting entry
-    /// count no longer fits the reserved TOC capacity, or when the tail would
-    /// push the WAD past the format's 4 GiB limit. The caller's fallback for
-    /// all of these is a full rebuild - and because nothing has been written,
-    /// it inherits an untouched WAD.
-    pub fn new(
-        layout: &WadTailLayout,
-        base_entries: BTreeMap<WadHash, WadChunk>,
-        tail: &'a [(WadHash, PreparedOverride)],
-    ) -> std::result::Result<Self, WadTailError> {
-        layout.validate()?;
-
-        let entry_count = merged_entry_count(&base_entries, tail.iter().map(|(hash, _)| *hash));
-        if !layout.admits_entry_count(entry_count) {
-            return Err(WadTailError::TocCapacity {
-                needed: entry_count,
-                reserved: layout.toc_capacity,
-            });
-        }
-
-        // Saturating rather than checked: any sum large enough to wrap a u64 is
-        // far past the 4 GiB limit the next check rejects it by, so there is
-        // nothing a separate overflow error would tell the caller.
-        let tail_end = tail.iter().fold(layout.tail_offset, |end, (_, over)| {
-            end.saturating_add(over.compressed().len() as u64)
-        });
-        if tail_end > MAX_WAD_OFFSET {
-            return Err(WadTailError::TailTooLarge { offset: tail_end });
-        }
-
-        Ok(Self {
-            layout: *layout,
-            entries: base_entries,
-            tail,
-            entry_count,
-            tail_end,
-        })
-    }
-
-    /// Bytes the rewritten override tail will occupy.
-    #[must_use]
-    pub fn tail_len(&self) -> u64 {
-        self.tail_end - self.layout.tail_offset
-    }
-
-    /// Entries the rewritten TOC will hold.
-    #[must_use]
-    pub fn entry_count(&self) -> usize {
-        self.entry_count
-    }
-
-    /// Write the tail and the TOC into `wad`, whose first byte is at `base`.
-    ///
-    /// `base` is where the WAD begins inside whatever holds it: `0` for a file
-    /// that is one WAD, and the entry's offset for a WAD stored inside an
-    /// archive. It shifts every seek and no recorded offset - a TOC entry
-    /// counts from the WAD's own first byte, because the game reads the WAD
-    /// without knowing what it is stored in.
-    ///
-    /// The caller owns the container, so the caller makes room: a file is
-    /// truncated to the layout's tail offset before this is called, and a WAD
-    /// inside an archive has its entry grown or shrunk by the difference
-    /// [`tail_len`](Self::tail_len) reports.
-    ///
-    /// # Errors
-    ///
-    /// Fails when the target refuses a write or a seek, or when a TOC entry
-    /// cannot be encoded. Every check that does not need the target was made
-    /// when the plan was built, so a failure here means the target itself gave
-    /// out - and, the write being in place, may leave a torn WAD. That is what
-    /// a caller's dirty marker exists to cover.
-    pub fn write<W: Write + Seek>(
-        mut self,
-        wad: &mut W,
-        base: u64,
-    ) -> std::result::Result<WadTailReport, WadTailError> {
-        let mut writer = BufWriter::with_capacity(WRITE_BUFFER_SIZE, wad);
-        writer.seek(SeekFrom::Start(base + self.layout.tail_offset))?;
-
-        let mut cursor = self.layout.tail_offset;
-        for (path_hash, over) in self.tail {
-            let chunk = write_tail_chunk(&mut writer, *path_hash, over, &mut cursor)?;
-            self.entries.insert(*path_hash, chunk);
-        }
-        let tail_len = cursor - self.layout.tail_offset;
-
-        // `entries` is a BTreeMap, so this walks the TOC in ascending hash order.
-        writer.seek(SeekFrom::Start(base + self.layout.chunk_count_offset()?))?;
-        writer.write_u32::<LE>(self.entries.len() as u32)?;
-        for chunk in self.entries.values() {
-            chunk.write_v3_4(&mut writer)?;
-        }
-        // Reserved slots this build did not fill are zeroed, as the full-rebuild
-        // path zeroes them: rewriting in place would otherwise leave the previous
-        // build's entries sitting past the new chunk count. Empty while
-        // `TOC_SLACK_ENTRIES` is zero, since capacity then equals the entry count.
-        for _ in self.entries.len()..self.layout.toc_capacity as usize {
-            writer.write_all(&[0u8; TOC_ENTRY_SIZE])?;
-        }
-
-        writer.flush()?;
-
-        Ok(WadTailReport {
-            entry_count: self.entries.len(),
-            tail_len,
-        })
-    }
 }
 
 /// Place the source region and the tail behind a TOC of `toc_capacity` entries.
@@ -1062,13 +713,19 @@ fn copy_source_region<W: Write>(writer: &mut W, mmap: &[u8], region: &Range<u64>
 fn write_tail_chunk<W: Write>(
     writer: &mut W,
     path_hash: WadHash,
-    over: &PreparedOverride,
+    over: &EncodedChunk,
     cursor: &mut u64,
-) -> std::result::Result<WadChunk, WadTailError> {
+    dst_wad_path: &Utf8Path,
+) -> Result<WadChunk> {
     let compressed_size = over.compressed().len();
     let end = *cursor + compressed_size as u64;
     if end > MAX_WAD_OFFSET {
-        return Err(WadTailError::TailTooLarge { offset: end });
+        return Err(WadLimitError::FileTooLarge {
+            wad: dst_wad_path.to_path_buf(),
+            region: WadRegion::OverrideTail,
+            offset: end,
+        }
+        .into());
     }
 
     let chunk = WadChunk {
@@ -1089,23 +746,13 @@ fn write_tail_chunk<W: Write>(
     Ok(chunk)
 }
 
-/// How many TOC entries a base entry set plus a set of tail hashes comes to.
-///
-/// A tail hash that is already a base entry replaces it rather than adding one,
-/// which is what lets an override that was removed revert to the game's bytes
-/// without changing the WAD's shape.
-pub(crate) fn merged_entry_count(
-    base_entries: &BTreeMap<WadHash, WadChunk>,
-    tail_hashes: impl IntoIterator<Item = WadHash>,
-) -> usize {
-    base_entries.len()
-        + tail_hashes
-            .into_iter()
-            .filter(|hash| !base_entries.contains_key(hash))
-            .count()
-}
-
 /// The number of TOC entries to reserve for `entry_count` chunks.
+///
+/// [`TOC_SLACK_ENTRIES`] must match the slack `ltk_wad` allows a rebase, which
+/// it keeps privately: reserving more here than a rebase admits would build
+/// WADs that every later rebase refuses, falling back to a full rebuild
+/// forever. [`WadTailLayout::admits_entry_count`] is what enforces the
+/// agreement, and both are zero today.
 ///
 /// # Errors
 ///

--- a/crates/ltk_overlay/src/wad_builder/tests.rs
+++ b/crates/ltk_overlay/src/wad_builder/tests.rs
@@ -6,145 +6,6 @@ const WAD_REL: &str = "DATA/FINAL/Champions/Test.wad.client";
 const SKIN: &str = "assets/characters/test/skins/skin0.dds";
 const VFX: &str = "assets/characters/test/particles.bin";
 
-/// Rewriting in place is destructive - the caller truncates the file before
-/// the write - so a rewrite that is going to be refused must be refused
-/// before that happens, or the fallback inherits a torn file it did not need
-/// to. Planning is what refuses, and a plan never touches the WAD.
-#[test]
-fn a_rejected_entry_count_leaves_the_file_untouched() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
-
-    let source_path = root.join("Game").join(WAD_REL);
-    write_game_wad(
-        &source_path,
-        &[(SKIN, b"the original skin"), (VFX, b"the original vfx")],
-    );
-
-    let overlay_path = root.join("overlay").join(WAD_REL);
-    let prepared =
-        PreparedOverride::compress(hash(SKIN), b"a modded skin").expect("override compresses");
-    let stats = build_patched_wad(
-        &source_path,
-        &overlay_path,
-        &[hash(SKIN)].into_iter().collect(),
-        |_| Ok(prepared.clone()),
-    )
-    .expect("the overlay WAD builds");
-
-    let base_entries: BTreeMap<WadHash, WadChunk> = {
-        let file = File::open(source_path.as_std_path()).unwrap();
-        let source = Wad::mount(std::io::BufReader::new(file)).unwrap();
-        source
-            .chunks()
-            .iter()
-            .map(|chunk| (chunk.path_hash, stats.layout.shifted(chunk).unwrap()))
-            .collect()
-    };
-
-    let before = std::fs::read(overlay_path.as_std_path()).unwrap();
-
-    // One chunk the file reserved no TOC entry for, which is exactly what
-    // the capacity check exists to refuse.
-    let new_entry = hash("assets/characters/test/brand_new.bin");
-    let tail = [(new_entry, prepared.clone())];
-    let refused = WadTailPlan::new(&stats.layout, base_entries, &tail);
-
-    assert!(
-        refused.is_err(),
-        "an over-capacity entry set must be refused"
-    );
-    assert_eq!(
-        std::fs::read(overlay_path.as_std_path()).unwrap(),
-        before,
-        "a refused rewrite must not have touched the file"
-    );
-}
-
-/// Story: the same rewrite, into a WAD that is not the whole file.
-///
-/// A WAD packed inside an archive starts partway through its container, so
-/// every seek the write makes has to be offset by where it begins - and every
-/// offset it *records* must not be, because the game reads the WAD without
-/// knowing what holds it. Getting that backwards produces a WAD whose TOC
-/// points at the container's bytes.
-#[test]
-fn a_tail_written_at_a_base_offset_reads_back_as_a_wad() {
-    use std::io::Cursor;
-
-    const BASE: u64 = 4096;
-
-    let tmp = tempfile::tempdir().unwrap();
-    let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
-
-    let source_path = root.join("Game").join(WAD_REL);
-    write_game_wad(
-        &source_path,
-        &[(SKIN, b"the original skin"), (VFX, b"the original vfx")],
-    );
-
-    let overlay_path = root.join("overlay").join(WAD_REL);
-    let first = PreparedOverride::compress(hash(SKIN), b"a modded skin").unwrap();
-    let stats = build_patched_wad(
-        &source_path,
-        &overlay_path,
-        &[hash(SKIN)].into_iter().collect(),
-        |_| Ok(first.clone()),
-    )
-    .expect("the overlay WAD builds");
-
-    let base_entries: BTreeMap<WadHash, WadChunk> = {
-        let file = File::open(source_path.as_std_path()).unwrap();
-        let source = Wad::mount(std::io::BufReader::new(file)).unwrap();
-        source
-            .chunks()
-            .iter()
-            .map(|chunk| (chunk.path_hash, stats.layout.shifted(chunk).unwrap()))
-            .collect()
-    };
-
-    // The container: padding, then the overlay WAD cut back to where its tail
-    // begins - which is what a caller makes room the same way for.
-    let built = std::fs::read(overlay_path.as_std_path()).unwrap();
-    let mut container = vec![0xAAu8; BASE as usize];
-    container.extend_from_slice(&built[..stats.layout.tail_offset as usize]);
-
-    let replacement = PreparedOverride::compress(hash(SKIN), b"a differently modded skin").unwrap();
-    let tail = [(hash(SKIN), replacement.clone())];
-    let plan =
-        WadTailPlan::new(&stats.layout, base_entries, &tail).expect("the plan is admissible");
-    let tail_len = plan.tail_len();
-
-    let mut cursor = Cursor::new(container);
-    let report = plan.write(&mut cursor, BASE).expect("the tail writes");
-    let container = cursor.into_inner();
-
-    assert_eq!(
-        report.tail_len, tail_len,
-        "the plan predicted the tail length"
-    );
-    assert_eq!(report.entry_count, 2);
-
-    // The padding is untouched: a write at a base offset stays inside the WAD.
-    assert!(
-        container[..BASE as usize].iter().all(|byte| *byte == 0xAA),
-        "the write ran back over the container's own bytes"
-    );
-
-    // And the region reads as a WAD in its own right, holding the replacement.
-    let mut wad = Wad::mount(Cursor::new(&container[BASE as usize..])).unwrap();
-    let chunk = *wad.chunks().get(hash(SKIN)).expect("the overridden chunk");
-    assert_eq!(
-        &*wad.load_chunk_decompressed(&chunk).unwrap(),
-        b"a differently modded skin"
-    );
-    let untouched = *wad.chunks().get(hash(VFX)).expect("the transient chunk");
-    assert_eq!(
-        &*wad.load_chunk_decompressed(&untouched).unwrap(),
-        b"the original vfx"
-    );
-}
-
 #[test]
 fn test_compress_with_none() {
     let data = b"Hello, world!";
@@ -159,39 +20,12 @@ fn test_compress_with_zstd() {
     assert!(compressed.len() < data.len());
 }
 
-/// A layout puts the chunk count and the TOC in front of its data region by
-/// subtraction, and `rewrite_wad_tail` seeks to that result and writes.
-/// A region offset that leaves no room for the header means those writes
-/// land on the magic and Riot's signature, so the layout must be refused
-/// before anything opens the file.
-#[test]
-fn a_layout_whose_toc_would_land_in_the_header_is_refused() {
-    // A v3.4 header is 268 bytes, so the smallest coherent region offset for
-    // a one-entry TOC is 268 + 4 (the chunk count) + 32 (the entry).
-    let smallest = WadTailLayout {
-        data_region_offset: 268 + 4 + 32,
-        offset_delta: 0,
-        tail_offset: 4096,
-        toc_capacity: 1,
-    };
-    assert!(
-        smallest.validate().is_ok(),
-        "the tightest legal layout must still be usable"
-    );
-
-    let in_the_header = WadTailLayout {
-        data_region_offset: 4 + 32,
-        ..smallest
-    };
-    assert!(
-        in_the_header.validate().is_err(),
-        "a region offset that leaves no room for the header must be refused"
-    );
-}
-
-/// The header size `validate` reserves is the one the writer actually emits.
-/// Pinning them against a real build stops the constant drifting from the
-/// bytes written above it.
+/// The header size `ltk_wad` reserves is the one this crate's writer emits.
+///
+/// `ltk_wad` pins the same property against its own builder; this pins it
+/// against ours, which is the half that can drift. A patched WAD whose TOC did
+/// not land where [`WadTailLayout::validate`] expects would be rebased by
+/// seeking into Riot's signature.
 #[test]
 fn a_built_wad_puts_its_toc_exactly_past_the_header() {
     let tmp = tempfile::tempdir().unwrap();
@@ -229,7 +63,7 @@ fn a_pass_through_recomputes_the_checksum_over_its_own_bytes() {
     const CONTENT: &[u8] = b"a chunk its container already holds compressed";
     let compressed = zstd::encode_all(CONTENT, 3).expect("test content compresses");
 
-    let over = PreparedOverride::pass_through(
+    let over = EncodedChunk::pass_through(
         hash(VFX),
         CompressedChunk {
             compressed: compressed.clone(),
@@ -270,7 +104,7 @@ fn a_passed_through_stored_chunk_reports_equal_sizes() {
     let source_path = root.join("Game").join(WAD_REL);
     write_game_wad(&source_path, &[(SKIN, b"the original skin")]);
 
-    let over = PreparedOverride::pass_through(
+    let over = EncodedChunk::pass_through(
         hash(SKIN),
         CompressedChunk {
             compressed: STORED.to_vec(),
@@ -322,7 +156,7 @@ fn a_codec_this_crate_does_not_emit_refuses_to_pass_through() {
         WadChunkCompression::Satellite,
         WadChunkCompression::ZstdMulti,
     ] {
-        let refused = PreparedOverride::pass_through(
+        let refused = EncodedChunk::pass_through(
             hash(VFX),
             CompressedChunk {
                 compressed: b"stored under a codec we do not write".to_vec(),

--- a/crates/ltk_overlay/src/wad_builder/tests.rs
+++ b/crates/ltk_overlay/src/wad_builder/tests.rs
@@ -6,9 +6,10 @@ const WAD_REL: &str = "DATA/FINAL/Champions/Test.wad.client";
 const SKIN: &str = "assets/characters/test/skins/skin0.dds";
 const VFX: &str = "assets/characters/test/particles.bin";
 
-/// Rewriting in place truncates the file before it writes, so a rewrite that
-/// is going to be refused must be refused before that happens - otherwise
-/// the caller's fallback inherits a torn file it did not need to.
+/// Rewriting in place is destructive - the caller truncates the file before
+/// the write - so a rewrite that is going to be refused must be refused
+/// before that happens, or the fallback inherits a torn file it did not need
+/// to. Planning is what refuses, and a plan never touches the WAD.
 #[test]
 fn a_rejected_entry_count_leaves_the_file_untouched() {
     let tmp = tempfile::tempdir().unwrap();
@@ -46,14 +47,8 @@ fn a_rejected_entry_count_leaves_the_file_untouched() {
     // One chunk the file reserved no TOC entry for, which is exactly what
     // the capacity check exists to refuse.
     let new_entry = hash("assets/characters/test/brand_new.bin");
-    let refused = rewrite_wad_tail(
-        &overlay_path,
-        &stats.layout,
-        stats.source,
-        base_entries,
-        &[new_entry],
-        |_| Ok(prepared.clone()),
-    );
+    let tail = [(new_entry, prepared.clone())];
+    let refused = WadTailPlan::new(&stats.layout, base_entries, &tail);
 
     assert!(
         refused.is_err(),
@@ -63,6 +58,90 @@ fn a_rejected_entry_count_leaves_the_file_untouched() {
         std::fs::read(overlay_path.as_std_path()).unwrap(),
         before,
         "a refused rewrite must not have touched the file"
+    );
+}
+
+/// Story: the same rewrite, into a WAD that is not the whole file.
+///
+/// A WAD packed inside an archive starts partway through its container, so
+/// every seek the write makes has to be offset by where it begins - and every
+/// offset it *records* must not be, because the game reads the WAD without
+/// knowing what holds it. Getting that backwards produces a WAD whose TOC
+/// points at the container's bytes.
+#[test]
+fn a_tail_written_at_a_base_offset_reads_back_as_a_wad() {
+    use std::io::Cursor;
+
+    const BASE: u64 = 4096;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+
+    let source_path = root.join("Game").join(WAD_REL);
+    write_game_wad(
+        &source_path,
+        &[(SKIN, b"the original skin"), (VFX, b"the original vfx")],
+    );
+
+    let overlay_path = root.join("overlay").join(WAD_REL);
+    let first = PreparedOverride::compress(hash(SKIN), b"a modded skin").unwrap();
+    let stats = build_patched_wad(
+        &source_path,
+        &overlay_path,
+        &[hash(SKIN)].into_iter().collect(),
+        |_| Ok(first.clone()),
+    )
+    .expect("the overlay WAD builds");
+
+    let base_entries: BTreeMap<WadHash, WadChunk> = {
+        let file = File::open(source_path.as_std_path()).unwrap();
+        let source = Wad::mount(std::io::BufReader::new(file)).unwrap();
+        source
+            .chunks()
+            .iter()
+            .map(|chunk| (chunk.path_hash, stats.layout.shifted(chunk).unwrap()))
+            .collect()
+    };
+
+    // The container: padding, then the overlay WAD cut back to where its tail
+    // begins - which is what a caller makes room the same way for.
+    let built = std::fs::read(overlay_path.as_std_path()).unwrap();
+    let mut container = vec![0xAAu8; BASE as usize];
+    container.extend_from_slice(&built[..stats.layout.tail_offset as usize]);
+
+    let replacement = PreparedOverride::compress(hash(SKIN), b"a differently modded skin").unwrap();
+    let tail = [(hash(SKIN), replacement.clone())];
+    let plan =
+        WadTailPlan::new(&stats.layout, base_entries, &tail).expect("the plan is admissible");
+    let tail_len = plan.tail_len();
+
+    let mut cursor = Cursor::new(container);
+    let report = plan.write(&mut cursor, BASE).expect("the tail writes");
+    let container = cursor.into_inner();
+
+    assert_eq!(
+        report.tail_len, tail_len,
+        "the plan predicted the tail length"
+    );
+    assert_eq!(report.entry_count, 2);
+
+    // The padding is untouched: a write at a base offset stays inside the WAD.
+    assert!(
+        container[..BASE as usize].iter().all(|byte| *byte == 0xAA),
+        "the write ran back over the container's own bytes"
+    );
+
+    // And the region reads as a WAD in its own right, holding the replacement.
+    let mut wad = Wad::mount(Cursor::new(&container[BASE as usize..])).unwrap();
+    let chunk = *wad.chunks().get(hash(SKIN)).expect("the overridden chunk");
+    assert_eq!(
+        &*wad.load_chunk_decompressed(&chunk).unwrap(),
+        b"a differently modded skin"
+    );
+    let untouched = *wad.chunks().get(hash(VFX)).expect("the transient chunk");
+    assert_eq!(
+        &*wad.load_chunk_decompressed(&untouched).unwrap(),
+        b"the original vfx"
     );
 }
 

--- a/crates/ltk_overlay/tests/rebuild.rs
+++ b/crates/ltk_overlay/tests/rebuild.rs
@@ -8,9 +8,9 @@
 use camino::{Utf8Path, Utf8PathBuf};
 use ltk_mod_project::{ModProject, ModProjectLayer};
 use ltk_overlay::utils::resolve_chunk_hash;
-use ltk_overlay::wad_builder::{PreparedOverride, build_patched_wad};
+use ltk_overlay::wad_builder::{OverrideEncoding as _, build_patched_wad};
 use ltk_overlay::{EnabledMod, FsModContent, OverlayBuilder};
-use ltk_wad::{Wad, WadBuilder, WadChunkBuilder, WadChunkCompression};
+use ltk_wad::{EncodedChunk, Wad, WadBuilder, WadChunkBuilder, WadChunkCompression};
 use std::collections::HashSet;
 use std::fs;
 use std::io::{Cursor, Write};
@@ -271,7 +271,7 @@ fn patched_wad_preserves_original_signature_and_checksum() {
         &src,
         &dst,
         &HashSet::from([override_hash, new_hash]),
-        |hash| PreparedOverride::compress(hash, b"MODDED"),
+        |hash| EncodedChunk::compress(hash, b"MODDED"),
     )
     .unwrap();
 

--- a/crates/ltk_overlay/tests/tail_layout.rs
+++ b/crates/ltk_overlay/tests/tail_layout.rs
@@ -11,8 +11,8 @@ mod common;
 
 use camino::Utf8PathBuf;
 use common::{assert_wad_is_well_formed, chunk_facts, hash, write_game_wad};
-use ltk_overlay::wad_builder::{PatchedWadStats, PreparedOverride, build_patched_wad};
-use ltk_wad::{Wad, WadHash};
+use ltk_overlay::wad_builder::{OverrideEncoding as _, PatchedWadStats, build_patched_wad};
+use ltk_wad::{EncodedChunk, Wad, WadHash};
 use std::collections::HashSet;
 use std::fs;
 
@@ -58,7 +58,7 @@ fn patch_fixture(
             .find(|(candidate, _)| *candidate == h)
             .map(|(_, bytes)| bytes.clone())
             .expect("the writer only asks for hashes it was given");
-        PreparedOverride::compress(h, &bytes)
+        EncodedChunk::compress(h, &bytes)
     })
     .expect("patched WAD builds");
 


### PR DESCRIPTION
Moves the WAD tail rebase out of `ltk_overlay` and onto `ltk_wad` 0.5.4's `WadRebasePlan`.

The mechanism was reshaped in place first (`1d84972`) so the move itself is mechanical: plan every
check that does not need the file, then write at a base offset. `ltk_wad` now owns that, which is
what lets a fantome repair rebase a packed WAD without the `ltk_overlay -> ltk_fantome -> ltk_wad`
cycle.

### What moved

| was | is |
| --- | --- |
| `WadTailPlan::new` | `ltk_wad::WadRebasePlan::tail` |
| `WadTailReport` / `WadTailError` | `WadRebaseReport` / `WadRebaseError` |
| `PreparedOverride` (data half) | `ltk_wad::EncodedChunk` |
| `merged_entry_count` free fn | `WadRebasePlan::merged_entry_count` |
| `WadTailLayout` | `ltk_wad::WadTailLayout`, re-exported from `wad_builder` |

`PreparedOverride`'s three constructors were overlay policy, not format, so they stay as a sealed
extension trait `OverrideEncoding for EncodedChunk`. A newtype would have added a layer that every
call site unwraps again before handing the chunk to a rebase, and the four accessors it would
forward are already `EncodedChunk`'s own.

### What deliberately did not move

`write_tail_chunk` and four of the five format constants stay: `write_patched_wad`, `plan_layout`
and `toc_capacity_for` still need them, and only `WAD_HEADER_SIZE` went dead. `write_tail_chunk`
also gets its richer pre-reshape error back, so `WadRegion::OverrideTail` stays constructible.

`tests/tail_layout.rs` stays too - all five of its tests drive `build_patched_wad`, the overlay's
own writer, not the rebase.

### Compatibility

`WadTailLayout` is persisted in every `OverlayState` on disk. Its four camelCase keys are unchanged,
and a rename upstream would not fail a build - the record would stop deserializing, `wad_layout`
would answer `None`, and every WAD would silently fall back to a full rebuild. `state.rs`'s
`a_layout_written_before_the_move_still_loads` pins them against literal JSON in both directions,
since a round trip would agree with itself whatever names were chosen.

### Verification

652 tests pass against published `ltk_wad` 0.5.4; `cargo fmt --check`, `clippy --all-targets` and
`doc --no-deps` clean.

### Known follow-ups, deliberately not done here

- `WadLimitError::ChunkUnaddressable` and `WadLimitError::TocCapacity` are now unconstructible.
  Removing them is its own decision, so they are documented rather than pruned.
- `TOC_SLACK_ENTRIES` is duplicated across the two crates and `ltk_wad`'s copy is private. If
  upstream raises it, every overlay WAD becomes unrebasable and falls back to full rebuilds
  silently. Worth exposing upstream.
- `resolve.rs` still says `prepared` / `supply_prepared` / `distribute_prepared_to_wads` after
  `PreparedOverride`'s deletion. ~40 sites across 5 files; wants its own commit rather than
  doubling this diff.
