### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "ltk_mod_project"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "camino",
  "ignore",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "ltk_overlay"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "byteorder",
  "camino",

--- a/crates/league-mod/Cargo.toml
+++ b/crates/league-mod/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.5.20", features = ["derive"] }
 miette = { version = "7", features = ["fancy"] }
 thiserror = "2.0"
 toml = "0.8.19"
-ltk_mod_project = { version = "0.9.1", path = "../ltk_mod_project", features = [
+ltk_mod_project = { version = "0.9.2", path = "../ltk_mod_project", features = [
     "modpkg",
     "fantome",
 ] }

--- a/crates/ltk_mod_project/CHANGELOG.md
+++ b/crates/ltk_mod_project/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2](https://github.com/LeagueToolkit/league-mod/compare/ltk_mod_project-v0.9.1...ltk_mod_project-v0.9.2) - 2026-09-01
+
+### Fixed
+
+- *(fantome)* skip unconvertible thumbnails on import
+
 ## [0.9.1](https://github.com/LeagueToolkit/league-mod/compare/ltk_mod_project-v0.9.0...ltk_mod_project-v0.9.1) - 2026-08-31
 
 ### Other

--- a/crates/ltk_mod_project/Cargo.toml
+++ b/crates/ltk_mod_project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ltk_mod_project"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Types and helpers for League Toolkit mod project definitions"

--- a/crates/ltk_overlay/CHANGELOG.md
+++ b/crates/ltk_overlay/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.9.7](https://github.com/LeagueToolkit/league-mod/compare/ltk_overlay-v0.9.6...ltk_overlay-v0.9.7) - 2026-09-01
+
+### Other
+
+- updated the following local packages: ltk_mod_project
+
 ## [0.9.6](https://github.com/LeagueToolkit/league-mod/compare/ltk_overlay-v0.9.5...ltk_overlay-v0.9.6) - 2026-08-31
 
 ### Fixed

--- a/crates/ltk_overlay/Cargo.toml
+++ b/crates/ltk_overlay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ltk_overlay"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "WAD overlay/profile builder for League of Legends mods"
@@ -15,7 +15,7 @@ authors = ["LeagueToolkit"]
 # LeagueToolkit crates
 ltk_wad = { workspace = true, features = ["serde"] }
 ltk_file = "0.2.8"
-ltk_mod_project = { version = "0.9.1", path = "../ltk_mod_project", features = ["fantome"] }
+ltk_mod_project = { version = "0.9.2", path = "../ltk_mod_project", features = ["fantome"] }
 ltk_modpkg = { version = "0.9.2", path = "../ltk_modpkg" }
 ltk_fantome = { version = "0.11.0", path = "../ltk_fantome" }
 indexmap = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `ltk_mod_project`: 0.9.1 -> 0.9.2 (✓ API compatible changes)
* `league-mod`: 0.2.1
* `ltk_overlay`: 0.9.6 -> 0.9.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `ltk_mod_project`

<blockquote>

## [0.9.2](https://github.com/LeagueToolkit/league-mod/compare/ltk_mod_project-v0.9.1...ltk_mod_project-v0.9.2) - 2026-09-01

### Fixed

- *(fantome)* skip unconvertible thumbnails on import
</blockquote>

## `league-mod`

<blockquote>

## [0.2.1](https://github.com/LeagueToolkit/league-mod/releases/tag/league-mod-v0.2.1) - 2025-11-21

### Added

- update version handling in metadata to use semver::Version
- add layers to metadata
- better meta handling
- use metadata chunk
- add support for signing mod packages (argument only)
- add check for update
- add color styling to clap output
- improve cli command and use miette
- add initial winget stuff
- add support for packing to fantome
- add option to specify thumbnail in mod project config

### Fixed

- minor clone stuff
- convert version to string format for consistent display in info_mod_package
- pack readme and thumbnail into modpkg
- fmt
- pad println output
- skip base layer conditionally
- layer presence lookup
- base skip
- error if explicit base layer
- typo

### Other

- *(league-mod)* bump version to v0.2.1
- *(league-mod)* release v0.2.0
- update release-plz configuration and add changelogs for new crates
- release
- include schema version when building metadata
- mark 'sign' field as dead code in PackModProjectArgs
- release
- bump version to 0.2.0
- add quick install instructions for league-mod using PowerShell
- bump league-mod version to 0.1.1
- prepare repo for crates releases
- remove comments
- fix checks
- fix deny licenses
- add ci workflow
- add release-plz
- add readme
- move existing mod crates
</blockquote>

## `ltk_overlay`

<blockquote>

## [0.9.7](https://github.com/LeagueToolkit/league-mod/compare/ltk_overlay-v0.9.6...ltk_overlay-v0.9.7) - 2026-09-01

### Other

- updated the following local packages: ltk_mod_project
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).